### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1135,7 +1135,7 @@ dependencies = [
 
 [[package]]
 name = "py-rustitude"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "nalgebra",
  "pyo3",
@@ -1322,7 +1322,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "criterion",
  "num_cpus",
@@ -1333,7 +1333,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude-core"
-version = "3.0.0"
+version = "3.1.0"
 dependencies = [
  "approx",
  "dyn-clone",
@@ -1354,7 +1354,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude-gluex"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "factorial",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["Nathaniel Dene Hoffman <dene@cmu.edu>"]
 description = "A library to create and operate models for particle physics amplitude analyses"
@@ -13,9 +13,9 @@ homepage = "https://github.com/denehoffman/rustitude/"
 license-file = "LICENSE"
 
 [workspace.dependencies]
-rustitude = { version = "0.7.0", path = "crates/rustitude", default-features = false }
-rustitude-core = { version = "3.0.0", path = "crates/rustitude-core", default-features = false }
-rustitude-gluex = { version = "0.4.1", path = "crates/rustitude-gluex", default-features = false }
+rustitude = { version = "0.7.1", path = "crates/rustitude", default-features = false }
+rustitude-core = { version = "3.1.0", path = "crates/rustitude-core", default-features = false }
+rustitude-gluex = { version = "0.4.2", path = "crates/rustitude-gluex", default-features = false }
 rayon = { version = "1.10.0" }
 approx = { version = "0.5.1", features = ["num-complex"] }
 nalgebra = "0.32.6"

--- a/crates/rustitude-core/CHANGELOG.md
+++ b/crates/rustitude-core/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.1.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.0.0...rustitude-core-v3.1.0) - 2024-06-17
+
+### Added
+- add intensity functions to ExtendedLogLikelihood and begin moving away from norm_int
+- move parameter parsing to Manager
+
+### Fixed
+- remove reference
+- ensure all loops are parallelized in par_* methods
+- resolve bug in product calculation
+
 ## [3.0.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v2.0.0...rustitude-core-v3.0.0) - 2024-06-10
 
 ### Added

--- a/crates/rustitude-core/Cargo.toml
+++ b/crates/rustitude-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustitude-core"
-version = "3.0.0"
+version = "3.1.0"
 edition = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }

--- a/crates/rustitude-gluex/CHANGELOG.md
+++ b/crates/rustitude-gluex/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.2](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.1...rustitude-gluex-v0.4.2) - 2024-06-17
+
+### Other
+- update Cargo.toml dependencies
+
 ## [0.4.1](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.0...rustitude-gluex-v0.4.1) - 2024-06-10
 
 ### Added

--- a/crates/rustitude-gluex/Cargo.toml
+++ b/crates/rustitude-gluex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustitude-gluex"
-version = "0.4.1"
+version = "0.4.2"
 edition = { workspace = true }
 authors = { workspace = true }
 description = "GlueX Amplitudes for Rustitude"

--- a/crates/rustitude/CHANGELOG.md
+++ b/crates/rustitude/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.1](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.0...rustitude-v0.7.1) - 2024-06-17
+
+### Added
+- add basic dataset read benchmark
+
 ## [0.7.0](https://github.com/denehoffman/rustitude/compare/rustitude-v0.6.0...rustitude-v0.7.0) - 2024-06-10
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `rustitude`: 0.7.0 -> 0.7.1
* `rustitude-core`: 3.0.0 -> 3.1.0
* `rustitude-gluex`: 0.4.1 -> 0.4.2
* `py-rustitude`: 0.7.0 -> 0.7.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustitude`
<blockquote>

## [0.7.1](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.0...rustitude-v0.7.1) - 2024-06-17

### Added
- add basic dataset read benchmark
</blockquote>

## `rustitude-core`
<blockquote>

## [3.1.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.0.0...rustitude-core-v3.1.0) - 2024-06-17

### Added
- add intensity functions to ExtendedLogLikelihood and begin moving away from norm_int
- move parameter parsing to Manager

### Fixed
- remove reference
- ensure all loops are parallelized in par_* methods
- resolve bug in product calculation
</blockquote>

## `rustitude-gluex`
<blockquote>

## [0.4.2](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.1...rustitude-gluex-v0.4.2) - 2024-06-17

### Other
- update Cargo.toml dependencies
</blockquote>

## `py-rustitude`
<blockquote>

## [0.7.0](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.6.0...py-rustitude-v0.7.0) - 2024-06-10

### Added
- [**breaking**] Restructures AmpOp into concrete types
- add par_ versions for all compute and norm_int methods and refactor python accordingly. Also remove RwLocks and extra allocations in the Amplitude struct, which is a huge speedup

### Other
- bump python package version
- Merge branch 'main' of https://github.com/denehoffman/rustitude
- fix README.md on python crate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).