### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -238,9 +238,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.0"
+version = "1.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+checksum = "b236fc92302c97ed75b38da1f4917b5cdda4984745740f153a5d3059e48d725e"
 
 [[package]]
 name = "byteorder"
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "py-rustitude"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "nalgebra",
  "pyo3",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude"
-version = "0.7.1"
+version = "0.7.2"
 dependencies = [
  "criterion",
  "num_cpus",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude-core"
-version = "3.1.0"
+version = "3.2.0"
 dependencies = [
  "approx",
  "dyn-clone",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude-gluex"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "factorial",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 authors = ["Nathaniel Dene Hoffman <dene@cmu.edu>"]
 description = "A library to create and operate models for particle physics amplitude analyses"
@@ -13,9 +13,9 @@ homepage = "https://github.com/denehoffman/rustitude/"
 license-file = "LICENSE"
 
 [workspace.dependencies]
-rustitude = { version = "0.7.1", path = "crates/rustitude", default-features = false }
-rustitude-core = { version = "3.1.0", path = "crates/rustitude-core", default-features = false }
-rustitude-gluex = { version = "0.4.2", path = "crates/rustitude-gluex", default-features = false }
+rustitude = { version = "0.7.2", path = "crates/rustitude", default-features = false }
+rustitude-core = { version = "3.2.0", path = "crates/rustitude-core", default-features = false }
+rustitude-gluex = { version = "0.4.3", path = "crates/rustitude-gluex", default-features = false }
 rayon = { version = "1.10.0" }
 approx = { version = "0.5.1", features = ["num-complex"] }
 nalgebra = "0.32.6"

--- a/crates/rustitude-core/CHANGELOG.md
+++ b/crates/rustitude-core/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.1.0...rustitude-core-v3.2.0) - 2024-06-19
+
+### Added
+- add some logging in for datasets and amplitudes
+- add (de)activate_all methods for Model, Manager, and ExtendedLogLikelihood
+
+### Fixed
+- temporarily remove automatic COM boost in dataset loading for parquet
+- update some Debug methods for clearer printing in downstream
+- the pol_in_beam convention actually sets Pz_Beam = 0, this corrects for that
+- deprecated methods should still work properly
+
+### Other
+- move important methods to beginning of impl block
+- add some notes to the Model::compute method
+- deprecate norm_int methods
+- remove print_tree and replace it with Debug
+
 ## [3.1.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.0.0...rustitude-core-v3.1.0) - 2024-06-17
 
 ### Added

--- a/crates/rustitude-core/Cargo.toml
+++ b/crates/rustitude-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustitude-core"
-version = "3.1.0"
+version = "3.2.0"
 edition = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }

--- a/crates/rustitude-gluex/CHANGELOG.md
+++ b/crates/rustitude-gluex/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.3](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.2...rustitude-gluex-v0.4.3) - 2024-06-19
+
+### Added
+- add pole_product scaling to reduce numerical error near mass poles
+
+### Fixed
+- corrected P_gamma multiplicative factor in Zlm and OnePS
+- corrected frame calculation in all HX/GJ-related amplitudes
+- add more digits to channel masses in all K-matrix amplitudes
+- corrected transposed g-matrix as well as a typo in one of the terms (channel 2 resonance 0)
+- corrected a flipped minus sign in Chew-Mandelstam matrix calculation
+
+### Other
+- get rid of warning in pole_product (temporary)
+- moved C-matrix to a chronologically sensible place
+- move postfix operator to prefix for clarity
+
 ## [0.4.2](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.1...rustitude-gluex-v0.4.2) - 2024-06-17
 
 ### Other

--- a/crates/rustitude-gluex/Cargo.toml
+++ b/crates/rustitude-gluex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustitude-gluex"
-version = "0.4.2"
+version = "0.4.3"
 edition = { workspace = true }
 authors = { workspace = true }
 description = "GlueX Amplitudes for Rustitude"

--- a/crates/rustitude/CHANGELOG.md
+++ b/crates/rustitude/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.2](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.1...rustitude-v0.7.2) - 2024-06-19
+
+### Other
+- deprecate norm_int methods
+
 ## [0.7.1](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.0...rustitude-v0.7.1) - 2024-06-17
 
 ### Added


### PR DESCRIPTION
## 🤖 New release
* `rustitude`: 0.7.1 -> 0.7.2
* `rustitude-core`: 3.1.0 -> 3.2.0
* `rustitude-gluex`: 0.4.2 -> 0.4.3
* `py-rustitude`: 0.7.1 -> 0.7.2

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustitude`
<blockquote>

## [0.7.2](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.1...rustitude-v0.7.2) - 2024-06-19

### Other
- deprecate norm_int methods
</blockquote>

## `rustitude-core`
<blockquote>

## [3.2.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.1.0...rustitude-core-v3.2.0) - 2024-06-19

### Added
- add some logging in for datasets and amplitudes
- add (de)activate_all methods for Model, Manager, and ExtendedLogLikelihood

### Fixed
- temporarily remove automatic COM boost in dataset loading for parquet
- update some Debug methods for clearer printing in downstream
- the pol_in_beam convention actually sets Pz_Beam = 0, this corrects for that
- deprecated methods should still work properly

### Other
- move important methods to beginning of impl block
- add some notes to the Model::compute method
- deprecate norm_int methods
- remove print_tree and replace it with Debug
</blockquote>

## `rustitude-gluex`
<blockquote>

## [0.4.3](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.2...rustitude-gluex-v0.4.3) - 2024-06-19

### Added
- add pole_product scaling to reduce numerical error near mass poles

### Fixed
- corrected P_gamma multiplicative factor in Zlm and OnePS
- corrected frame calculation in all HX/GJ-related amplitudes
- add more digits to channel masses in all K-matrix amplitudes
- corrected transposed g-matrix as well as a typo in one of the terms (channel 2 resonance 0)
- corrected a flipped minus sign in Chew-Mandelstam matrix calculation

### Other
- get rid of warning in pole_product (temporary)
- moved C-matrix to a chronologically sensible place
- move postfix operator to prefix for clarity
</blockquote>

## `py-rustitude`
<blockquote>

## [0.7.0](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.6.0...py-rustitude-v0.7.0) - 2024-06-10

### Added
- [**breaking**] Restructures AmpOp into concrete types
- add par_ versions for all compute and norm_int methods and refactor python accordingly. Also remove RwLocks and extra allocations in the Amplitude struct, which is a huge speedup

### Other
- bump python package version
- Merge branch 'main' of https://github.com/denehoffman/rustitude
- fix README.md on python crate
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).