### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "py-rustitude"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "nalgebra",
  "pyo3",
@@ -1328,7 +1328,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude"
-version = "0.7.2"
+version = "0.7.3"
 dependencies = [
  "criterion",
  "num_cpus",
@@ -1339,7 +1339,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude-core"
-version = "3.2.0"
+version = "3.3.0"
 dependencies = [
  "approx",
  "dyn-clone",
@@ -1361,7 +1361,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude-gluex"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "factorial",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.2"
+version = "0.7.3"
 edition = "2021"
 authors = ["Nathaniel Dene Hoffman <dene@cmu.edu>"]
 description = "A library to create and operate models for particle physics amplitude analyses"
@@ -13,9 +13,9 @@ homepage = "https://github.com/denehoffman/rustitude/"
 license-file = "LICENSE"
 
 [workspace.dependencies]
-rustitude = { version = "0.7.2", path = "crates/rustitude", default-features = false }
-rustitude-core = { version = "3.2.0", path = "crates/rustitude-core", default-features = false }
-rustitude-gluex = { version = "0.4.3", path = "crates/rustitude-gluex", default-features = false }
+rustitude = { version = "0.7.3", path = "crates/rustitude", default-features = false }
+rustitude-core = { version = "3.3.0", path = "crates/rustitude-core", default-features = false }
+rustitude-gluex = { version = "0.4.4", path = "crates/rustitude-gluex", default-features = false }
 rayon = { version = "1.10.0" }
 approx = { version = "0.5.1", features = ["num-complex"] }
 nalgebra = "0.32.6"

--- a/crates/rustitude-core/CHANGELOG.md
+++ b/crates/rustitude-core/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.3.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.2.0...rustitude-core-v3.3.0) - 2024-06-20
+
+### Added
+- add rustitude_core::utils mod to hold some nice testing functions
+- re-export nalgebra::Vector3 in rustitude_core::prelude since it gets used so often
+- add convenience method for turning Nodes into Amplitudes
+
+### Fixed
+- corrected behavior of deactivated Amplitudes
+
+### Other
+- Merge pull request [#11](https://github.com/denehoffman/rustitude/pull/11) from denehoffman/development
+- add tests for some GlueX amplitudes as well as some of the main crate functionality
+- add a bit of documentation to rustitude_core::errors module
+- update parameter display methods
+
 ## [3.2.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.1.0...rustitude-core-v3.2.0) - 2024-06-19
 
 ### Added

--- a/crates/rustitude-core/Cargo.toml
+++ b/crates/rustitude-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustitude-core"
-version = "3.2.0"
+version = "3.3.0"
 edition = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }

--- a/crates/rustitude-gluex/CHANGELOG.md
+++ b/crates/rustitude-gluex/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.4](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.3...rustitude-gluex-v0.4.4) - 2024-06-20
+
+### Added
+- re-export nalgebra::Vector3 in rustitude_core::prelude since it gets used so often
+
+### Other
+- Merge pull request [#11](https://github.com/denehoffman/rustitude/pull/11) from denehoffman/development
+- add tests for some GlueX amplitudes as well as some of the main crate functionality
+
 ## [0.4.3](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.2...rustitude-gluex-v0.4.3) - 2024-06-19
 
 ### Added

--- a/crates/rustitude-gluex/Cargo.toml
+++ b/crates/rustitude-gluex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustitude-gluex"
-version = "0.4.3"
+version = "0.4.4"
 edition = { workspace = true }
 authors = { workspace = true }
 description = "GlueX Amplitudes for Rustitude"

--- a/py-rustitude/CHANGELOG.md
+++ b/py-rustitude/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.3](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.7.2...py-rustitude-v0.7.3) - 2024-06-20
+
+### Fixed
+- from_dict should not assume Pz_Beam = E_Beam
+
+### Other
+- Merge pull request [#11](https://github.com/denehoffman/rustitude/pull/11) from denehoffman/development
+
 ## [0.7.0](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.6.0...py-rustitude-v0.7.0) - 2024-06-10
 
 ### Added

--- a/py-rustitude/pyproject.toml
+++ b/py-rustitude/pyproject.toml
@@ -10,7 +10,7 @@ features = ["pyo3/extension-module"]
 name = "rustitude"
 description = "Python bindings for the Rustitude library"
 readme = "README.md"
-version = "0.7.2"
+version = "0.7.3"
 requires-python = ">=3.7"
 license = { file = "LICENSE" }
 keywords = ["physics", "math", "rust"]


### PR DESCRIPTION
## 🤖 New release
* `rustitude`: 0.7.2 -> 0.7.3
* `rustitude-core`: 3.2.0 -> 3.3.0
* `rustitude-gluex`: 0.4.3 -> 0.4.4
* `py-rustitude`: 0.7.2 -> 0.7.3

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustitude`
<blockquote>

## [0.7.2](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.1...rustitude-v0.7.2) - 2024-06-19

### Other
- deprecate norm_int methods
</blockquote>

## `rustitude-core`
<blockquote>

## [3.3.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.2.0...rustitude-core-v3.3.0) - 2024-06-20

### Added
- add rustitude_core::utils mod to hold some nice testing functions
- re-export nalgebra::Vector3 in rustitude_core::prelude since it gets used so often
- add convenience method for turning Nodes into Amplitudes

### Fixed
- corrected behavior of deactivated Amplitudes

### Other
- Merge pull request [#11](https://github.com/denehoffman/rustitude/pull/11) from denehoffman/development
- add tests for some GlueX amplitudes as well as some of the main crate functionality
- add a bit of documentation to rustitude_core::errors module
- update parameter display methods
</blockquote>

## `rustitude-gluex`
<blockquote>

## [0.4.4](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.3...rustitude-gluex-v0.4.4) - 2024-06-20

### Added
- re-export nalgebra::Vector3 in rustitude_core::prelude since it gets used so often

### Other
- Merge pull request [#11](https://github.com/denehoffman/rustitude/pull/11) from denehoffman/development
- add tests for some GlueX amplitudes as well as some of the main crate functionality
</blockquote>

## `py-rustitude`
<blockquote>

## [0.7.3](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.7.2...py-rustitude-v0.7.3) - 2024-06-20

### Fixed
- from_dict should not assume Pz_Beam = E_Beam

### Other
- Merge pull request [#11](https://github.com/denehoffman/rustitude/pull/11) from denehoffman/development
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).