### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1141,7 +1141,7 @@ dependencies = [
 
 [[package]]
 name = "py-rustitude"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "nalgebra",
  "pyo3",
@@ -1329,7 +1329,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude"
-version = "0.7.3"
+version = "0.7.4"
 dependencies = [
  "criterion",
  "num_cpus",
@@ -1340,7 +1340,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude-core"
-version = "3.3.0"
+version = "3.4.0"
 dependencies = [
  "approx",
  "dyn-clone",
@@ -1362,7 +1362,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude-gluex"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "factorial",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.3"
+version = "0.7.4"
 edition = "2021"
 authors = ["Nathaniel Dene Hoffman <dene@cmu.edu>"]
 description = "A library to create and operate models for particle physics amplitude analyses"
@@ -13,9 +13,9 @@ homepage = "https://github.com/denehoffman/rustitude/"
 license-file = "LICENSE"
 
 [workspace.dependencies]
-rustitude = { version = "0.7.3", path = "crates/rustitude", default-features = false }
-rustitude-core = { version = "3.3.0", path = "crates/rustitude-core", default-features = false }
-rustitude-gluex = { version = "0.4.4", path = "crates/rustitude-gluex", default-features = false }
+rustitude = { version = "0.7.4", path = "crates/rustitude", default-features = false }
+rustitude-core = { version = "3.4.0", path = "crates/rustitude-core", default-features = false }
+rustitude-gluex = { version = "0.4.5", path = "crates/rustitude-gluex", default-features = false }
 rayon = { version = "1.10.0" }
 approx = { version = "0.5.1", features = ["num-complex"] }
 nalgebra = "0.32.6"

--- a/crates/rustitude-core/CHANGELOG.md
+++ b/crates/rustitude-core/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.4.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.3.0...rustitude-core-v3.4.0) - 2024-06-21
+
+### Added
+- Add the ability to create new Nodes in Python
+- add error type for PyErr so they can be converted back to RustitudeError
+
+### Fixed
+- finish error handling for custom PyNode GIL issues
+
+### Other
+- Merge branch 'main' into development
+
 ## [3.3.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.2.0...rustitude-core-v3.3.0) - 2024-06-20
 
 ### Added

--- a/crates/rustitude-core/Cargo.toml
+++ b/crates/rustitude-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustitude-core"
-version = "3.3.0"
+version = "3.4.0"
 edition = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }

--- a/crates/rustitude-gluex/CHANGELOG.md
+++ b/crates/rustitude-gluex/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.5](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.4...rustitude-gluex-v0.4.5) - 2024-06-21
+
+### Other
+- update Cargo.toml dependencies
+
 ## [0.4.4](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.3...rustitude-gluex-v0.4.4) - 2024-06-20
 
 ### Added

--- a/crates/rustitude-gluex/Cargo.toml
+++ b/crates/rustitude-gluex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustitude-gluex"
-version = "0.4.4"
+version = "0.4.5"
 edition = { workspace = true }
 authors = { workspace = true }
 description = "GlueX Amplitudes for Rustitude"

--- a/crates/rustitude/CHANGELOG.md
+++ b/crates/rustitude/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.4](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.3...rustitude-v0.7.4) - 2024-06-21
+
+### Other
+- Merge branch 'main' into development
+- reduce number of samples in read_dataset benchmark
+
 ## [0.7.2](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.1...rustitude-v0.7.2) - 2024-06-19
 
 ### Other

--- a/py-rustitude/CHANGELOG.md
+++ b/py-rustitude/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.4](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.7.3...py-rustitude-v0.7.4) - 2024-06-21
+
+### Added
+- Add the ability to create new Nodes in Python
+
+### Fixed
+- finish error handling for custom PyNode GIL issues
+
+### Other
+- Merge branch 'main' into development
+
 ## [0.7.3](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.7.2...py-rustitude-v0.7.3) - 2024-06-20
 
 ### Fixed

--- a/py-rustitude/pyproject.toml
+++ b/py-rustitude/pyproject.toml
@@ -10,7 +10,7 @@ features = ["pyo3/extension-module"]
 name = "rustitude"
 description = "Python bindings for the Rustitude library"
 readme = "README.md"
-version = "0.7.3"
+version = "0.7.4"
 requires-python = ">=3.7"
 license = { file = "LICENSE" }
 keywords = ["physics", "math", "rust"]
@@ -27,7 +27,7 @@ dependencies = ["uproot", "numpy"]
 homepage = "https://github.com/denehoffman/rustitude"
 repository = "https://github.com/denehoffman/rustitude"
 changelog = "https://github.com/denehoffman/rustitude/blob/main/CHANGELOG.md"
-# TODO: documentation = "readthedocs.org"
+documentation = "https://rustitude.readthedocs.io/en/latest/"
 
 [tool.ruff]
 line-length = 100


### PR DESCRIPTION
## 🤖 New release
* `rustitude`: 0.7.3 -> 0.7.4
* `rustitude-core`: 3.3.0 -> 3.4.0
* `rustitude-gluex`: 0.4.4 -> 0.4.5
* `py-rustitude`: 0.7.3 -> 0.7.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustitude`
<blockquote>

## [0.7.4](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.3...rustitude-v0.7.4) - 2024-06-21

### Other
- Merge branch 'main' into development
- reduce number of samples in read_dataset benchmark
</blockquote>

## `rustitude-core`
<blockquote>

## [3.4.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.3.0...rustitude-core-v3.4.0) - 2024-06-21

### Added
- Add the ability to create new Nodes in Python
- add error type for PyErr so they can be converted back to RustitudeError

### Fixed
- finish error handling for custom PyNode GIL issues

### Other
- Merge branch 'main' into development
</blockquote>

## `rustitude-gluex`
<blockquote>

## [0.4.5](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.4...rustitude-gluex-v0.4.5) - 2024-06-21

### Other
- update Cargo.toml dependencies
</blockquote>

## `py-rustitude`
<blockquote>

## [0.7.4](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.7.3...py-rustitude-v0.7.4) - 2024-06-21

### Added
- Add the ability to create new Nodes in Python

### Fixed
- finish error handling for custom PyNode GIL issues

### Other
- Merge branch 'main' into development
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).