### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -841,9 +841,9 @@ dependencies = [
 
 [[package]]
 name = "num-bigint"
-version = "0.4.5"
+version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c165a9ab64cf766f73521c0dd2cfdff64f488b8f0b3e621face3462d3db536d7"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
 dependencies = [
  "num-integer",
  "num-traits",
@@ -1092,7 +1092,7 @@ dependencies = [
 
 [[package]]
 name = "py-rustitude"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "nalgebra",
  "pyo3",
@@ -1271,7 +1271,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude"
-version = "0.7.4"
+version = "0.8.0"
 dependencies = [
  "criterion",
  "num_cpus",
@@ -1282,7 +1282,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude-core"
-version = "3.4.0"
+version = "4.0.0"
 dependencies = [
  "approx",
  "dyn-clone",
@@ -1303,7 +1303,7 @@ dependencies = [
 
 [[package]]
 name = "rustitude-gluex"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "factorial",
  "nalgebra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 default-members = ["crates/*"]
 
 [workspace.package]
-version = "0.7.4"
+version = "0.8.0"
 edition = "2021"
 authors = ["Nathaniel Dene Hoffman <dene@cmu.edu>"]
 description = "A library to create and operate models for particle physics amplitude analyses"
@@ -13,9 +13,9 @@ homepage = "https://github.com/denehoffman/rustitude/"
 license-file = "LICENSE"
 
 [workspace.dependencies]
-rustitude = { version = "0.7.4", path = "crates/rustitude", default-features = false }
-rustitude-core = { version = "3.4.0", path = "crates/rustitude-core", default-features = false }
-rustitude-gluex = { version = "0.4.5", path = "crates/rustitude-gluex", default-features = false }
+rustitude = { version = "0.8.0", path = "crates/rustitude", default-features = false }
+rustitude-core = { version = "4.0.0", path = "crates/rustitude-core", default-features = false }
+rustitude-gluex = { version = "0.4.6", path = "crates/rustitude-gluex", default-features = false }
 rayon = { version = "1.10.0" }
 approx = { version = "0.5.1", features = ["num-complex"] }
 nalgebra = "0.33.0"

--- a/crates/rustitude-core/CHANGELOG.md
+++ b/crates/rustitude-core/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.0.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.4.0...rustitude-core-v4.0.0) - 2024-06-27
+
+### Added
+- remove RwLock from Dataset and adopt indexing methods for splitting data
+- [**breaking**] add indexed versions of all evaluators and selectors
+- add isolate method as a shortcut for activating a set of amplitudes
+
+### Fixed
+- fix model debug
+- remove prints from tests
+- remove unused imports
+- make parameters initialize at 1.0 rather than 0.0
+- change FourMomentum sum implementation to take owned copies
+- update ELL evaluate methods to use the sum of weights rather than number of events and add normalization to intensity functions
+- remove const functions for now, they fail on nightly
+
+### Other
+- *(amplitude)* fix doctest
+- remove unused dependencies
+- update dependencies
+- remove deprecated norm_int methods
+- *(four_momentum)* add some more tests for FourMomentum methods
+- remove simd feature (for now)
+- add custom node reference to rustitude-core README.md
+- update all README.mds
+
 ## [3.4.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.3.0...rustitude-core-v3.4.0) - 2024-06-21
 
 ### Added

--- a/crates/rustitude-core/Cargo.toml
+++ b/crates/rustitude-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustitude-core"
-version = "3.4.0"
+version = "4.0.0"
 edition = { workspace = true }
 authors = { workspace = true }
 description = { workspace = true }

--- a/crates/rustitude-gluex/CHANGELOG.md
+++ b/crates/rustitude-gluex/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.6](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.5...rustitude-gluex-v0.4.6) - 2024-06-27
+
+### Added
+- remove RwLock from Dataset and adopt indexing methods for splitting data
+
+### Fixed
+- change FourMomentum sum implementation to take owned copies
+
+### Other
+- update all README.mds
+
 ## [0.4.5](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.4...rustitude-gluex-v0.4.5) - 2024-06-21
 
 ### Other

--- a/crates/rustitude-gluex/Cargo.toml
+++ b/crates/rustitude-gluex/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustitude-gluex"
-version = "0.4.5"
+version = "0.4.6"
 edition = { workspace = true }
 authors = { workspace = true }
 description = "GlueX Amplitudes for Rustitude"

--- a/crates/rustitude/CHANGELOG.md
+++ b/crates/rustitude/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.4...rustitude-v0.8.0) - 2024-06-27
+
+### Added
+- add benchmark for indexed evaluation
+
+### Other
+- corrected mistake in README.md
+- update all README.mds
+- update badges
+
 ## [0.7.4](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.3...rustitude-v0.7.4) - 2024-06-21
 
 ### Other

--- a/docs/source/binned_fits.rst
+++ b/docs/source/binned_fits.rst
@@ -1,0 +1,131 @@
+Binned Fits
+===========
+
+It is often useful to bin particle data by mass or Mandelstam-t to fit model-independent amplitudes separately in each bin. rustitude offers a mechanism to do this using event indices.
+
+Example
+-------
+
+Suppose we have some data, and we want to fit polarized spherical harmonics to these data without providing a model for the mass. We can do this by binning by mass and fitting the amplitudes separately in each bin.
+
+.. code-block:: python
+
+   import rustitude as rt
+   import numpy as np
+   import matplotlib.pyplot as plt
+
+First, we collect the data. Let's split these data into bins of mass, let's say 40 bins in a range of 1-2 GeV.
+
+.. code-block:: python
+
+   ds_data = rt.open("data.root")
+   ds_accmc = rt.open("accmc.root")
+
+   ds_data_split, _, _ = ds_data.split_m(bins=40, range=(1, 2))
+   ds_accmc_split, _, _ = ds_accmc.split_m(bins=40, range=(1, 2))
+
+These are just lists of lists of indices! We ignore the last two outputs, as they represent the under/overflow bins.
+
+Let's fit an S0+ wave, a P-1+ wave, and a D2- wave. We also need to set up some free parameters, since the Zlm amplitudes are fixed with respect to the data. It's important to make two of them scalars rather than complex scalars, as coherent sums are invariant up to an overall phase.
+
+.. code-block:: python
+
+
+   z00p = rt.gluex.harmonics.Zlm("Z00+", l=0, m=0, reflectivity="+")
+   z1m1p = rt.gluex.harmonics.Zlm("Z1-1+", l=1, m=-1, reflectivity="+")
+   z22m = rt.gluex.harmonics.Zlm("Z22-", l=2, m=2, reflectivity="-")
+
+   s0p = rt.Scalar("S0+")
+   pm1p = rt.CScalar("P-1+")
+   d2m = rt.Scalar("D2-")
+
+
+Next, we set up our model:
+
+.. code-block:: python
+
+   positive_real_sum = s0p * z00p.real() + pm1p * z1m1p.real()
+   positive_imag_sum = s0p * z00p.imag() + pm1p * z1m1p.imag()
+   # as_cohsum() because it's a single term:
+   negative_real_sum = (d2m * z22m.real()).as_cohsum()
+   negative_imag_sum = (d2m * z22m.imag()).as_cohsum()
+
+   model = rt.Model([positive_real_sum, positive_imag_sum, negative_real_sum, negative_imag_sum])
+   nll = rt.ExtendedLogLikelihood(rt.Manager(model, ds_data), rt.Manager(model, ds_accmc))
+
+Let's give our parameters some reasonable bounds (this is just a guess).
+
+.. code-block:: python
+
+   for parameter in nll.parameters:
+       nll.set_bounds(parameter.amplitude, parameter.name, (-1000, 1000))
+
+We can now use the minimizer interface to create some fit objects. Let's use Minuit via the iminuit package!
+
+.. code-block:: python
+
+   ms = [rt.minimizer(nll,
+                      method="Minuit",
+                      indices_data=indices_data,
+                      indices_mc=indices_mc,
+                      num_threads=8)
+         for indices_data, indices_mc in zip(ds_data_split, ds_accmc_split)]
+   
+Run the fits (with the Migrad algorithm)!
+
+.. code-block:: python
+
+   for ibin, m in enumerate(ms):
+       print(f"Fitting bin {i}")
+       m.migrad()
+
+Now we collect the results. We can sum the intensities for each event in each bin separately, and use the "isolate" method to select a subset of waves to evaluate.
+
+.. code-block:: python
+
+   intensity_tot = [sum(nll.intensity(list(m.values),
+                                      ds_accmc,
+                                      indices_data=indices_data,
+                                      indices_mc=indices_mc,
+                                      num_threads=8))
+                    for m, indices_data, indices_mc in zip(ms, ds_data_split, ds_accmc_split)]
+
+   nll.isolate(["Z00+", "S0+"])
+   intensity_s0p = [sum(nll.intensity(list(m.values),
+                                      ds_accmc,
+                                      indices_data=indices_data,
+                                      indices_mc=indices_mc,
+                                      num_threads=8))
+                    for m, indices_data, indices_mc in zip(ms, ds_data_split, ds_accmc_split)]
+
+   nll.isolate(["Z1-1+", "P-1+"])
+   intensity_pm1p = [sum(nll.intensity(list(m.values),
+                                       ds_accmc,
+                                       indices_data=indices_data,
+                                       indices_mc=indices_mc,
+                                       num_threads=8))
+                     for m, indices_data, indices_mc in zip(ms, ds_data_split, ds_accmc_split)]
+
+   nll.isolate(["Z22-", "D2-"])
+   intensity_d2m = [sum(nll.intensity(list(m.values),
+                                      ds_accmc,
+                                      indices_data=indices_data,
+                                      indices_mc=indices_mc,
+                                      num_threads=8))
+                    for m, indices_data, indices_mc in zip(ms, ds_data_split, ds_accmc_split)]
+
+Finally, we can plot the results:
+
+.. code-block:: python
+
+   m_data = [(e.daughter_p4s[0] + e.daughter_p4s[1]).m for e in ds_data.events]
+   bin_edges = np.histogram_bin_edges([], bins=40, range=(1, 2))
+   plt.hist(m_data, weights=ds_data.weights, bins=40, range=(1, 2), histtype='step', label="Data")
+   plt.stairs(intensity_tot, bin_edges, label="Fit Total")
+   plt.stairs(intensity_s0p, bin_edges, label="$S_{0}^{(+)}")
+   plt.stairs(intensity_pm1p, bin_edges, label="$P_{-1}^{(+)}")
+   plt.stairs(intensity_d2m, bin_edges, label="$D_{2}^{(-)}")
+   plt.legend()
+   plt.show()
+
+From here, we'd usually go through the process of modifying the model to produce the most sensible fit, and to really make a complete study, we might generate some sets of indices that can be thought of as bootstrapped data. If we were fitting all of the data at once, we could use the :code:`Dataset.get_bootstrap_indices(self, seed: int)` method to generate such a set, but here we might favor using native Python methods to resample the binned indices we generated above. Note that sorting said indices will probably lead to better performance. Bootstrapped indices can be used the exact same way as the indices were used above, and after collecting intensities from each bootstrap fit, we just need to find the standard deviation to put error bars on the plot we just made, but for now that will be an exercise for the user.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -91,12 +91,18 @@ Contents
    :caption: Contents:
 
    general_usage
+   binned_fits
    custom_nodes
 
 General Usage
 ^^^^^^^^^^^^^
 
 Learn about the basic concepts and how to use rustitude for amplitude analysis.
+
+Binned Fits
+^^^^^^^^^^^
+
+Learn how rustitude can be used to fit mass-binned data.
 
 Writing Custom Nodes
 ^^^^^^^^^^^^^^^^^^^^

--- a/py-rustitude/CHANGELOG.md
+++ b/py-rustitude/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.7.4...py-rustitude-v0.8.0) - 2024-06-27
+
+### Added
+- remove RwLock from Dataset and adopt indexing methods for splitting data
+- [**breaking**] add indexed versions of all evaluators and selectors
+- add isolate method as a shortcut for activating a set of amplitudes
+- add as_minuit and minimize functions to python API
+- add fixed/free properties to parameters in python API
+
+### Fixed
+- opt-in to py-clone feature and get rid of another deprecation warning
+- add scipy and iminuit dependencies to python package
+- update pol_in_beam method on python API to correctly load Beam_P4 and EPS
+- remove const functions for now, they fail on nightly
+
+### Other
+- update dependencies
+- remove deprecated norm_int methods
+- corrected mistake in README.md
+- update all README.mds
+- update badges
+
 ## [0.7.4](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.7.3...py-rustitude-v0.7.4) - 2024-06-21
 
 ### Added

--- a/py-rustitude/pyproject.toml
+++ b/py-rustitude/pyproject.toml
@@ -10,7 +10,7 @@ features = ["pyo3/extension-module"]
 name = "rustitude"
 description = "Python bindings for the Rustitude library"
 readme = "README.md"
-version = "0.7.4"
+version = "0.8.0"
 requires-python = ">=3.7"
 license = { file = "LICENSE" }
 keywords = ["physics", "math", "rust"]


### PR DESCRIPTION
## 🤖 New release
* `rustitude`: 0.7.4 -> 0.8.0
* `rustitude-core`: 3.4.0 -> 4.0.0
* `rustitude-gluex`: 0.4.5 -> 0.4.6
* `py-rustitude`: 0.7.4 -> 0.8.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `rustitude`
<blockquote>

## [0.8.0](https://github.com/denehoffman/rustitude/compare/rustitude-v0.7.4...rustitude-v0.8.0) - 2024-06-27

### Added
- add benchmark for indexed evaluation

### Other
- corrected mistake in README.md
- update all README.mds
- update badges
</blockquote>

## `rustitude-core`
<blockquote>

## [4.0.0](https://github.com/denehoffman/rustitude/compare/rustitude-core-v3.4.0...rustitude-core-v4.0.0) - 2024-06-27

### Added
- remove RwLock from Dataset and adopt indexing methods for splitting data
- [**breaking**] add indexed versions of all evaluators and selectors
- add isolate method as a shortcut for activating a set of amplitudes

### Fixed
- fix model debug
- remove prints from tests
- remove unused imports
- make parameters initialize at 1.0 rather than 0.0
- change FourMomentum sum implementation to take owned copies
- update ELL evaluate methods to use the sum of weights rather than number of events and add normalization to intensity functions
- remove const functions for now, they fail on nightly

### Other
- *(amplitude)* fix doctest
- remove unused dependencies
- update dependencies
- remove deprecated norm_int methods
- *(four_momentum)* add some more tests for FourMomentum methods
- remove simd feature (for now)
- add custom node reference to rustitude-core README.md
- update all README.mds
</blockquote>

## `rustitude-gluex`
<blockquote>

## [0.4.6](https://github.com/denehoffman/rustitude/compare/rustitude-gluex-v0.4.5...rustitude-gluex-v0.4.6) - 2024-06-27

### Added
- remove RwLock from Dataset and adopt indexing methods for splitting data

### Fixed
- change FourMomentum sum implementation to take owned copies

### Other
- update all README.mds
</blockquote>

## `py-rustitude`
<blockquote>

## [0.8.0](https://github.com/denehoffman/rustitude/compare/py-rustitude-v0.7.4...py-rustitude-v0.8.0) - 2024-06-27

### Added
- remove RwLock from Dataset and adopt indexing methods for splitting data
- [**breaking**] add indexed versions of all evaluators and selectors
- add isolate method as a shortcut for activating a set of amplitudes
- add as_minuit and minimize functions to python API
- add fixed/free properties to parameters in python API

### Fixed
- opt-in to py-clone feature and get rid of another deprecation warning
- add scipy and iminuit dependencies to python package
- update pol_in_beam method on python API to correctly load Beam_P4 and EPS
- remove const functions for now, they fail on nightly

### Other
- update dependencies
- remove deprecated norm_int methods
- corrected mistake in README.md
- update all README.mds
- update badges
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).