### PR TITLE
Avoid duplication of precomputed data when cloning Models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -69,9 +69,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstyle"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "038dfcf04a5feb68e9c60b21c9625a54c2c0616e79b72b0fd87075a056ae1d1b"
+checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
 
 [[package]]
 name = "approx"
@@ -85,9 +85,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-array"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81c16ec702d3898c2f5cfdc148443c6cd7dbe5bac28399859eb0a3d38f072827"
+checksum = "16f4a9468c882dc66862cef4e1fd8423d47e67972377d85d80e022786427768c"
 dependencies = [
  "ahash",
  "arrow-buffer",
@@ -101,9 +101,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-buffer"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cae6970bab043c4fbc10aee1660ceb5b306d0c42c8cc5f6ae564efcd9759b663"
+checksum = "c975484888fc95ec4a632cdc98be39c085b1bb518531b0c80c5d462063e5daa1"
 dependencies = [
  "bytes",
  "half",
@@ -112,9 +112,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-cast"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c7ef44f26ef4f8edc392a048324ed5d757ad09135eff6d5509e6450d39e0398"
+checksum = "da26719e76b81d8bc3faad1d4dbdc1bcc10d14704e63dc17fc9f3e7e1e567c8e"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -132,9 +132,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-data"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a769666ffac256dd301006faca1ca553d0ae7cffcf4cd07095f73f95eb226514"
+checksum = "dd9d6f18c65ef7a2573ab498c374d8ae364b4a4edf67105357491c031f716ca5"
 dependencies = [
  "arrow-buffer",
  "arrow-schema",
@@ -144,9 +144,9 @@ dependencies = [
 
 [[package]]
 name = "arrow-ipc"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbf9c3fb57390a1af0b7bb3b5558c1ee1f63905f3eccf49ae7676a8d1e6e5a72"
+checksum = "e786e1cdd952205d9a8afc69397b317cfbb6e0095e445c69cda7e8da5c1eeb0f"
 dependencies = [
  "arrow-array",
  "arrow-buffer",
@@ -158,15 +158,15 @@ dependencies = [
 
 [[package]]
 name = "arrow-schema"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dab1c12b40e29d9f3b699e0203c2a73ba558444c05e388a4377208f8f9c97eee"
+checksum = "9e972cd1ff4a4ccd22f86d3e53e835c2ed92e0eea6a3e8eadb72b4f1ac802cf8"
 
 [[package]]
 name = "arrow-select"
-version = "52.1.0"
+version = "52.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e80159088ffe8c48965cb9b1a7c968b2729f29f37363df7eca177fc3281fe7c3"
+checksum = "600bae05d43483d216fb3494f8c32fdbefd8aa4e1de237e790dbb3d9f44690a3"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -202,6 +202,12 @@ name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
 name = "brotli"
@@ -256,9 +262,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2aba8f4e9906c7ce3c73463f62a7f0c65183ada1a2d47e397cc8810827f9694f"
+checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
 dependencies = [
  "jobserver",
  "libc",
@@ -313,18 +319,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.10"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f6b81fb3c84f5563d509c59b5a48d935f689e993afa90fe39047f05adef9142"
+checksum = "35723e6a11662c2afb578bcf0b88bf6ea8e21282a953428f240574fcc3a2b5b3"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.10"
+version = "4.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca6706fd5224857d9ac5eb9355f6683563cc0541c7cd9d014043b57cbec78ac"
+checksum = "49eb96cbfa7cfa35017b7cd548c75b14c3118c98b423041d70562665e07fb0fa"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -332,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+checksum = "1462739cb27611015575c0c11df5df7601141071f07518d56fcc1be504cbec97"
 
 [[package]]
 name = "const-random"
@@ -478,7 +484,7 @@ version = "24.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8add37afff2d4ffa83bc748a70b4b1370984f6980768554182424ef71447c35f"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "rustc_version",
 ]
 
@@ -494,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "ganesh"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0d5ed3ff5cdece560ee30dfdf0edc7049e5f31f65b0273559466f687e7d9c1"
+checksum = "04dd876c93f8ea6689644153ff91c5792fe58c7bba5b94d0801065b88afa1556"
 dependencies = [
  "nalgebra",
  "num-traits",
@@ -729,6 +735,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
 
 [[package]]
+name = "lock_api"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
+dependencies = [
+ "autocfg",
+ "scopeguard",
+]
+
+[[package]]
 name = "log"
 version = "0.4.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -776,9 +792,9 @@ dependencies = [
 
 [[package]]
 name = "matrixmultiply"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7574c1cf36da4798ab73da5b215bbf444f50718207754cb522201d78d1cd0ff2"
+checksum = "9380b911e3e96d10c1f415da0876389aaf1b56759054eeb0de7df940c456ba1a"
 dependencies = [
  "autocfg",
  "rawpointer",
@@ -975,10 +991,33 @@ dependencies = [
 ]
 
 [[package]]
-name = "parquet"
-version = "52.1.0"
+name = "parking_lot"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f22ba0d95db56dde8685e3fadcb915cdaadda31ab8abbe3ff7f0ad1ef333267"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall",
+ "smallvec",
+ "windows-targets",
+]
+
+[[package]]
+name = "parquet"
+version = "52.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e977b9066b4d3b03555c22bdc442f3fadebd96a39111249113087d0edb2691cd"
 dependencies = [
  "ahash",
  "arrow-array",
@@ -1061,9 +1100,13 @@ checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.17"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+checksum = "2288c0e17cc8d342c712bb43a257a80ebffce59cdb33d5000d8348f3ec02528b"
+dependencies = [
+ "zerocopy",
+ "zerocopy-derive",
+]
 
 [[package]]
 name = "primal-bit"
@@ -1243,6 +1286,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "regex"
 version = "1.10.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1305,6 +1357,7 @@ dependencies = [
  "num-complex",
  "num-traits",
  "oxyroot",
+ "parking_lot",
  "parquet",
  "pyo3",
  "rayon",
@@ -1352,6 +1405,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scopeguard"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,11 +1444,12 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.120"
+version = "1.0.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e0d21c9a8cae1235ad58a00c11cb40d4b1e5c784f1ef2c537876ed6ffd8b7c5"
+checksum = "4ab380d7d9f22ef3f21ad3e6c1ebe8e4fc7a2000ccba2e4d71fc96f15b2cb609"
 dependencies = [
  "itoa",
+ "memchr",
  "ryu",
  "serde",
 ]
@@ -1612,9 +1672,9 @@ checksum = "81dfa00651efa65069b0b6b651f4aaa31ba9e3c3ce0137aaad053604ee7e0314"
 
 [[package]]
 name = "version_check"
-version = "0.9.4"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"
@@ -1812,6 +1872,7 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
+ "byteorder",
  "zerocopy-derive",
 ]
 
@@ -1846,9 +1907,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.11+zstd.1.5.6"
+version = "2.0.12+zstd.1.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75652c55c0b6f3e6f12eb786fe1bc960396bf05a1eb3bf1f3691c3610ac2e6d4"
+checksum = "0a4e40c320c3cb459d9a9ff6de98cff88f4751ee9275d140e2be94a2b74e4c13"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,8 @@ fastrand = "2.1.0"
 num_cpus = "1.16.0"
 dyn-clone = "1.0.17"
 tracing = "0.1.40"
-ganesh = "0.3.0"
+ganesh = "0.4.0"
+parking_lot = "0.12.3"
 
 [profile.release]
 lto = true

--- a/crates/rustitude-core/Cargo.toml
+++ b/crates/rustitude-core/Cargo.toml
@@ -25,6 +25,7 @@ dyn-clone = { workspace = true }
 tracing = { workspace = true }
 fastrand = { workspace = true }
 ganesh = { workspace = true }
+parking_lot = { workspace = true }
 
 [features]
 default = []

--- a/crates/rustitude-core/src/manager.rs
+++ b/crates/rustitude-core/src/manager.rs
@@ -64,10 +64,11 @@ impl<F: Field> Manager<F> {
             .iter()
             .map(|p| p.index.map_or_else(|| p.initial, |i| parameters[i]))
             .collect();
+        let amplitudes = self.model.amplitudes.read();
         self.dataset
             .events
             .iter()
-            .map(|event: &Event<F>| self.model.compute(&pars, event))
+            .map(|event: &Event<F>| self.model.compute(&amplitudes, &pars, event))
             .collect()
     }
 
@@ -98,9 +99,13 @@ impl<F: Field> Manager<F> {
             .iter()
             .map(|p| p.index.map_or_else(|| p.initial, |i| parameters[i]))
             .collect();
+        let amplitudes = self.model.amplitudes.read();
         indices
             .iter()
-            .map(|index| self.model.compute(&pars, &self.dataset.events[*index]))
+            .map(|index| {
+                self.model
+                    .compute(&amplitudes, &pars, &self.dataset.events[*index])
+            })
             .collect()
     }
 
@@ -126,10 +131,11 @@ impl<F: Field> Manager<F> {
             .iter()
             .map(|p| p.index.map_or_else(|| p.initial, |i| parameters[i]))
             .collect();
+        let amplitudes = self.model.amplitudes.read();
         self.dataset
             .events
             .par_iter()
-            .map(|event| self.model.compute(&pars, event))
+            .map(|event| self.model.compute(&amplitudes, &pars, event))
             .collect_into_vec(&mut output);
         output.into_iter().collect()
     }
@@ -168,12 +174,13 @@ impl<F: Field> Manager<F> {
         //     .par_iter()
         //     .map(|index| self.model.compute(&pars, &self.dataset.events[*index]))
         //     .collect_into_vec(&mut output);
+        let amplitudes = self.model.amplitudes.read();
         let view: Vec<&Event<F>> = indices
             .par_iter()
             .map(|&index| &self.dataset.events[index])
             .collect();
         view.par_iter()
-            .map(|&event| self.model.compute(&pars, event))
+            .map(|&event| self.model.compute(&amplitudes, &pars, event))
             .collect_into_vec(&mut output);
         output.into_iter().collect()
     }

--- a/py-rustitude/rustitude/__init__.py
+++ b/py-rustitude/rustitude/__init__.py
@@ -187,9 +187,11 @@ def open(
         tree_arrays['Px_Beam'] = np.zeros_like(tree_arrays['Px_Beam'])
         tree_arrays['Py_Beam'] = np.zeros_like(tree_arrays['Py_Beam'])
         tree_arrays['Pz_Beam'] = tree_arrays['E_Beam']
-        tree_arrays['EPS'] = [np.array([ex, ey, ez]) for ex, ey, ez in zip(eps_x, eps_y, eps_z)]
+        tree_arrays['EPS'] = np.array([
+            np.array([ex, ey, ez]) for ex, ey, ez in zip(eps_x, eps_y, eps_z)
+        ])
     elif eps is not None:
-        tree_arrays['EPS'] = [np.array(eps) for _ in range(len(tree_arrays['Weight']))]
+        tree_arrays['EPS'] = np.array([np.array(eps) for _ in range(len(tree_arrays['Weight']))])
     if f32:
         return Dataset_32.from_dict(tree_arrays)
     else:

--- a/py-rustitude/src/amplitude.rs
+++ b/py-rustitude/src/amplitude.rs
@@ -889,6 +889,7 @@ impl Model_64 {
     fn amplitudes(&self) -> Vec<Amplitude_64> {
         self.0
             .amplitudes
+            .read()
             .clone()
             .into_iter()
             .map(Amplitude_64::from)
@@ -1051,6 +1052,7 @@ impl Model_32 {
     fn amplitudes(&self) -> Vec<Amplitude_32> {
         self.0
             .amplitudes
+            .read()
             .clone()
             .into_iter()
             .map(Amplitude_32::from)

--- a/py-rustitude/src/manager.rs
+++ b/py-rustitude/src/manager.rs
@@ -48,6 +48,7 @@ impl Manager_64 {
         self.0
             .model
             .amplitudes
+            .read()
             .clone()
             .into_iter()
             .map(Amplitude_64::from)
@@ -236,6 +237,7 @@ impl Manager_32 {
         self.0
             .model
             .amplitudes
+            .read()
             .clone()
             .into_iter()
             .map(Amplitude_32::from)
@@ -431,6 +433,7 @@ impl ExtendedLogLikelihood_64 {
             .data_manager
             .model
             .amplitudes
+            .read()
             .clone()
             .into_iter()
             .map(Amplitude_64::from)
@@ -704,6 +707,7 @@ impl ExtendedLogLikelihood_32 {
             .data_manager
             .model
             .amplitudes
+            .read()
             .clone()
             .into_iter()
             .map(Amplitude_32::from)


### PR DESCRIPTION
Previously, cloning a `Model` (or `Manager`/`ExtendedLogLikelihood`) would result in a duplication of precomputed data inside the contained `Amplitude`s. I added `parking-lot` back in to handle the `Arc<RwLock<Vec<Amplitude<F>>>>` field of `Model`, and modified the `Model::compute` method to pass a locked set of `Amplitude`s rather than locking them separately in each call. The lock happens in the `Manager` methods now, so we minimize performance issues there while reducing RAM usage greatly across the board. Aside from making the inefficient clone of an `ExtendedLogLikelihood` when doing fits much more memory efficient, it also seems to be beneficial in some of the loading methods in the Python API, although I'm honestly not quite sure why. Either way, it's a large memory improvement for a minimal performance hit, so I'm going forward with the release.