### PR TITLE
Updates to trait systems

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,6 +9,16 @@ build:
   os: ubuntu-22.04
   tools:
     python: "3.12"
+    rust: "1.82"
+
+python:
+  install:
+    - method: pip
+      path: py-rustitude/.
+
+formats:
+  - pdf
+  - epub
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "version_check",
- "zerocopy 0.7.35",
+ "zerocopy",
 ]
 
 [[package]]
@@ -238,9 +238,9 @@ checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "102087e286b4677862ea56cf8fc58bb2cdfa8725c40ffb80fe3a008eb7f2fc83"
+checksum = "6fd4c6dcc3b0aea2f5c0b4b82c2b15fe39ddbc76041a310848f4706edf76bb31"
 
 [[package]]
 name = "byteorder"
@@ -262,12 +262,13 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.7"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26a5c3fd7bfa1ce3897a3a3501d362b2d87b7f2583ebcb4a949ec25911025cbc"
+checksum = "72db2f7947ecee9b03b510377e8bb9077afa27176fdbff55c51027e976fdcc48"
 dependencies = [
  "jobserver",
  "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -319,18 +320,18 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.13"
+version = "4.5.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fbb260a053428790f3de475e304ff84cdbc4face759ea7a3e64c1edd938a7fc"
+checksum = "ed6719fffa43d0d87e5fd8caeab59be1554fb028cd30edc88fc4369b17971019"
 dependencies = [
  "clap_builder",
 ]
 
 [[package]]
 name = "clap_builder"
-version = "4.5.13"
+version = "4.5.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64b17d7ea74e9f833c7dbf2cbe4fb12ff26783eda4782a8975b72f895c9b4d99"
+checksum = "216aec2b177652e3846684cbfe25c9964d18ec45234f0f5da5157b207ed1aab6"
 dependencies = [
  "anstyle",
  "clap_lex",
@@ -364,9 +365,9 @@ dependencies = [
 
 [[package]]
 name = "core-foundation-sys"
-version = "0.8.6"
+version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ea2b9bc92be3c2baa9334a323ebca2d6f074ff852cd1d7b11064035cd3868f"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "crc32fast"
@@ -490,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "flate2"
-version = "1.0.30"
+version = "1.0.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f54427cfd1c7829e2a139fcefea601bf088ebca651d2bf53ebc600eac295dae"
+checksum = "7f211bbe8e69bbd0cfdea405084f128ae8b4aaa6b0b522fc8f2b009084797920"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -500,11 +501,12 @@ dependencies = [
 
 [[package]]
 name = "ganesh"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dd876c93f8ea6689644153ff91c5792fe58c7bba5b94d0801065b88afa1556"
+checksum = "e1e5161faf44f18f3479193edb1eb149d6be37b0a0025eb7ce3e36fd26f780aa"
 dependencies = [
  "nalgebra",
+ "num",
  "num-traits",
  "typed-builder",
 ]
@@ -565,6 +567,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
+name = "hermit-abi"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -601,13 +609,13 @@ checksum = "8bb03732005da905c88227371639bf1ad885cc712789c011c31c5fb3ab3ccf02"
 
 [[package]]
 name = "is-terminal"
-version = "0.4.12"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f23ff5ef2b80d608d61efee834934d862cd92461afc0560dedf493e4c033738b"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.4.0",
  "libc",
- "windows-sys",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -654,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29c15563dc2726973df627357ce0c9ddddbea194836909d655df6a75d2cf296d"
+checksum = "1868808506b929d7b0cfa8f75951347aa71bb21144b7791bae35d9bccfcfe37a"
 dependencies = [
  "wasm-bindgen",
 ]
@@ -733,9 +741,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.156"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "a5f43f184355eefb8d17fc948dbecf6c13be3c141f20d834ae842193a448c72a"
 
 [[package]]
 name = "libm"
@@ -866,7 +874,7 @@ checksum = "254a5372af8fc138e36684761d3c0cdb758a4410e938babcff1c860ce14ddbfc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -910,7 +918,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -960,7 +968,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.3.9",
  "libc",
 ]
 
@@ -1118,11 +1126,11 @@ checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee4364d9f3b902ef14fab8a1ddffb783a1cb6b4bba3bfc1fa3922732c7de97f"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy 0.6.6",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1221,7 +1229,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1234,7 +1242,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1443,35 +1451,41 @@ checksum = "a3f0bf26fd526d2a95683cd0f87bf103b8539e2ca1ef48ce002d67aad59aa0b4"
 
 [[package]]
 name = "serde"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc76f558e0cbb2a839d37354c575f1dc3fdc6546b5be373ba43d95f231bf7c12"
+checksum = "cff085d2cb684faa248efb494c39b68e522822ac0de72ccf08109abde717cfb2"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.204"
+version = "1.0.208"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
+checksum = "24008e81ff7613ed8e5ba0cfaf24e2c2f1e5b8a0495711e44fcd4882fca62bcf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
 name = "serde_json"
-version = "1.0.122"
+version = "1.0.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "784b6203951c57ff748476b126ccb5e8e2959a5c19e5c617ab1956be3dbc68da"
+checksum = "83c8e735a073ccf5be70aa8066aa984eaf2fa000db6c8d0100ae605b366d31ed"
 dependencies = [
  "itoa",
  "memchr",
  "ryu",
  "serde",
 ]
+
+[[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "simba"
@@ -1528,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.72"
+version = "2.0.75"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc4b9b9bf2add8093d3f2c0204471e951b2285580335de42f9d2534f3ae7a8af"
+checksum = "f6af063034fc1935ede7be0122941bafa9bacb949334d090b77ca98b5817c7d9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1560,7 +1574,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1612,7 +1626,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1647,22 +1661,22 @@ dependencies = [
 
 [[package]]
 name = "typed-builder"
-version = "0.18.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77739c880e00693faef3d65ea3aad725f196da38b22fdc7ea6ded6e1ce4d3add"
+checksum = "a06fbd5b8de54c5f7c91f6fe4cebb949be2125d7758e630bb58b1d831dbce600"
 dependencies = [
  "typed-builder-macro",
 ]
 
 [[package]]
 name = "typed-builder-macro"
-version = "0.18.2"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f718dfaf347dcb5b983bfc87608144b0bad87970aebcbea5ce44d2a30c08e63"
+checksum = "f9534daa9fd3ed0bd911d462a37f172228077e7abf18c18a5f67199d959205f8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]
@@ -1713,34 +1727,35 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4be2531df63900aeb2bca0daaaddec08491ee64ceecbee5076636a3b026795a8"
+checksum = "a82edfc16a6c469f5f44dc7b571814045d60404b55a0ee849f9bcfa2e63dd9b5"
 dependencies = [
  "cfg-if",
+ "once_cell",
  "wasm-bindgen-macro",
 ]
 
 [[package]]
 name = "wasm-bindgen-backend"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "614d787b966d3989fa7bb98a654e369c762374fd3213d212cfc0251257e747da"
+checksum = "9de396da306523044d3302746f1208fa71d7532227f15e347e2d93e4145dd77b"
 dependencies = [
  "bumpalo",
  "log",
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1f8823de937b71b9460c0c34e25f3da88250760bec0ebac694b49997550d726"
+checksum = "585c4c91a46b072c92e908d99cb1dcdf95c5218eeb6f3bf1efa991ee7a68cccf"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1748,28 +1763,28 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e94f17b526d0a461a191c78ea52bbce64071ed5c04c9ffe424dcb38f74171bb7"
+checksum = "afc340c74d9005395cf9dd098506f7f44e38f2b4a21c6aaacf9a105ea5e1e836"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.92"
+version = "0.2.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af190c94f2773fdb3729c55b007a722abb5384da03bc0986df4c289bf5567e96"
+checksum = "c62a0a307cb4a311d3a07867860911ca130c3494e8c2719593806c08bc5d0484"
 
 [[package]]
 name = "web-sys"
-version = "0.3.69"
+version = "0.3.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77afa9a11836342370f4817622a2f0f418b134426d91a82dfb48f532d2ec13ef"
+checksum = "26fdeaafd9bd129f65e7c031593c24d62186301e0c72c8978fa1678be7d532c0"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1777,9 +1792,9 @@ dependencies = [
 
 [[package]]
 name = "wide"
-version = "0.7.26"
+version = "0.7.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "901e8597c777fa042e9e245bd56c0dc4418c5db3f845b6ff94fbac732c6a0692"
+checksum = "b828f995bf1e9622031f8009f8481a85406ce1f4d4588ff746d872043e855690"
 dependencies = [
  "bytemuck",
  "safe_arch",
@@ -1802,11 +1817,11 @@ dependencies = [
 
 [[package]]
 name = "winapi-util"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d4cc384e1e73b93bafa6fb4f1df8c41695c8a91cf9c4c64358067d15a7b6c6b"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1823,6 +1838,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -1902,32 +1926,12 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "854e949ac82d619ee9a14c66a1b674ac730422372ccb759ce0c39cabcf2bf8e6"
-dependencies = [
- "byteorder",
- "zerocopy-derive 0.6.6",
-]
-
-[[package]]
-name = "zerocopy"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive 0.7.35",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.6.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "125139de3f6b9d625c39e2efdd73d41bdac468ccd556556440e322be0e1bbd91"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.72",
+ "byteorder",
+ "zerocopy-derive",
 ]
 
 [[package]]
@@ -1938,7 +1942,7 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.72",
+ "syn 2.0.75",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ fastrand = "2.1.0"
 num_cpus = "1.16.0"
 dyn-clone = "1.0.17"
 tracing = "0.1.40"
-ganesh = "0.4.0"
+ganesh = "0.6.0"
 parking_lot = "0.12.3"
 wigners = "0.3.0"
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ f2 = gluex.resonances.KMatrixF2('f2', channel=2)
 a0p = gluex.resonances.KMatrixA0('a0+', channel=1)
 a0n = gluex.resonances.KMatrixA0('a0-', channel=1)
 a2 = gluex.resonances.KMatrixA2('a2', channel=1)
-s0p = gluex.harmonics.Zlm('Z00+', 0, 0, reflectivity=gluex.Reflectivity.Positive)
-s0n = gluex.harmonics.Zlm('Z00-', 0, 0, reflectivity=gluex.Reflectivity.Negative)
+s0p = gluex.harmonics.Zlm('Z00+', l=0, m=0, reflectivity='+')
+s0n = gluex.harmonics.Zlm('Z00-', 0, 0, '-')
 d2p = gluex.harmonics.Zlm('Z22+', 2, 2) # positive reflectivity is the default
 
 # Next, let's put them together into a model
@@ -122,6 +122,10 @@ nll = rt.ExtendedLogLikelihood(m_data, m_mc)
 
 res = nll([10.0] * mod.n_free) # automatic CPU parallelism without GIL
 print(res) # prints some value for the NLL
+
+mi = rt.minimizer(nll, method='Minuit') # use iminuit to create a Minuit minimizer
+mi.migrad() # run the Migrad algorithm
+print(mi) # print the fit result
 ```
 
 Automatic parallelism over the CPU can be disabled via function calls which support it (for example, `nll([10.0] * mod.n_free, parallel=False)` would run without parallel processing), and the number of CPUs used can be controlled via the `RAYON_NUM_THREADS` environment variable, which can be set before the code is run or modified inside the code (for example, `os.environ['RAYON_NUM_THREADS] = '5'` would ensure only five threads are used past that point in the code). By default, an unset value or the value of `'0'` will use all available cores.

--- a/crates/rustitude-core/src/amplitude.rs
+++ b/crates/rustitude-core/src/amplitude.rs
@@ -130,7 +130,7 @@ impl<F: Field> Display for Parameter<F> {
 /// A trait which contains all the required methods for a functioning [`Amplitude`].
 ///
 /// The [`Node`] trait represents any mathematical structure which takes in some parameters and some
-/// [`Event`] data and computes a [`ComplexField`] for each [`Event`]. This is the fundamental
+/// [`Event`] data and computes a [`Complex`] for each [`Event`]. This is the fundamental
 /// building block of all analyses built with Rustitude. Nodes are intended to be optimized at the
 /// user level, so they should be implemented on structs which can store some precalculated data.
 ///
@@ -260,7 +260,7 @@ pub trait Node<F: Field>: Sync + Send + DynClone {
         Ok(())
     }
 
-    /// A method which runs every time the amplitude is evaluated and produces a [`ComplexField`].
+    /// A method which runs every time the amplitude is evaluated and produces a [`Complex`].
     ///
     /// Because this method is run on every evaluation, it should be as lean as possible.
     /// Additionally, you should avoid [`rayon`]'s parallel loops inside this method since we
@@ -405,7 +405,7 @@ pub trait AsTree {
 pub struct Amplitude<F: Field> {
     /// A name which uniquely identifies an [`Amplitude`] within a sum and group.
     pub name: String,
-    /// A [`Node`] which contains all of the operations needed to compute a [`ComplexField`] from an
+    /// A [`Node`] which contains all of the operations needed to compute a [`Complex`] from an
     /// [`Event`] in a [`Dataset`], a [`Vec<Field>`] of parameter values, and possibly some
     /// precomputed values.
     pub node: Box<dyn Node<F>>,

--- a/crates/rustitude-core/src/amplitude.rs
+++ b/crates/rustitude-core/src/amplitude.rs
@@ -50,6 +50,7 @@ use std::{
 use tracing::{debug, info};
 
 use crate::{
+    convert,
     dataset::{Dataset, Event},
     errors::RustitudeError,
     Field,
@@ -88,7 +89,7 @@ impl<F: Field> Parameter<F> {
             index: Some(index),
             fixed_index: None,
             initial: F::one(),
-            bounds: (F::NEG_INFINITY, F::INFINITY),
+            bounds: (F::neg_infinity(), F::infinity()),
         }
     }
 
@@ -203,12 +204,12 @@ impl<F: Field> Display for Parameter<F> {
 ///                 let beam_res_vec = event.beam_p4.boost_along(&resonance).momentum();
 ///                 let recoil_res_vec = event.recoil_p4.boost_along(&resonance).momentum();
 ///                 let daughter_res_vec = event.daughter_p4s[0].boost_along(&resonance).momentum();
-///                 let z = -recoil_res_vec.normalize();
+///                 let z = -recoil_res_vec.unit();
 ///                 let y = event
 ///                     .beam_p4
 ///                     .momentum()
 ///                     .cross(&(-recoil_res_vec))
-///                     .normalize();
+///                     .unit();
 ///                 let x = y.cross(&z);
 ///                 let p = Coordinates::cartesian(
 ///                     daughter_res_vec.dot(&x),
@@ -1392,7 +1393,7 @@ pub fn cscalar<F: Field>(name: &str) -> Amplitude<F> {
 /// - `phi`: The phase of the complex scalar.
 #[derive(Clone)]
 pub struct PolarComplexScalar;
-impl<F: Field + num::Float> Node<F> for PolarComplexScalar {
+impl<F: Field> Node<F> for PolarComplexScalar {
     fn calculate(&self, parameters: &[F], _event: &Event<F>) -> Result<Complex<F>, RustitudeError> {
         Ok(Complex::cis(parameters[1]).mul(parameters[0]))
     }
@@ -1416,7 +1417,7 @@ impl<F: Field + num::Float> Node<F> for PolarComplexScalar {
 /// let my_pcscalar: Amplitude<f64> = pcscalar("MyPolarComplexScalar");
 /// assert_eq!(my_pcscalar.parameters, vec!["mag".to_string(), "phi".to_string()]);
 /// ```
-pub fn pcscalar<F: Field + num::Float>(name: &str) -> Amplitude<F> {
+pub fn pcscalar<F: Field>(name: &str) -> Amplitude<F> {
     Amplitude::new(name, PolarComplexScalar)
 }
 
@@ -1435,17 +1436,17 @@ where
 impl<V, F> Piecewise<V, F>
 where
     V: Fn(&Event<F>) -> F + Send + Sync + Copy,
-    F: Field + num::Float,
+    F: Field,
 {
     /// Create a new [`Piecewise`] struct from a number of bins, a range of values, and a callable
     /// which defines a variable over the [`Event`]s in a [`Dataset`].
     pub fn new(bins: usize, range: (F, F), variable: V) -> Self {
-        let diff = (range.1 - range.0) / <F as Field>::convert_usize(bins);
+        let diff = (range.1 - range.0) / convert!(bins, F);
         let edges = (0..bins)
             .map(|i| {
                 (
-                    num::Float::mul_add(<F as Field>::convert_usize(i), diff, range.0),
-                    num::Float::mul_add(<F as Field>::convert_usize(i + 1), diff, range.0),
+                    F::mul_add(convert!(i, F), diff, range.0),
+                    F::mul_add(convert!(i + 1, F), diff, range.0),
                 )
             })
             .collect();
@@ -1488,7 +1489,7 @@ where
     }
 }
 
-pub fn piecewise_m<F: Field + num::Float>(name: &str, bins: usize, range: (F, F)) -> Amplitude<F> {
+pub fn piecewise_m<F: Field + 'static>(name: &str, bins: usize, range: (F, F)) -> Amplitude<F> {
     //! Creates a named [`Piecewise`] amplitude with the resonance mass as the binning variable.
     Amplitude::new(
         name,
@@ -1500,7 +1501,7 @@ pub fn piecewise_m<F: Field + num::Float>(name: &str, bins: usize, range: (F, F)
 
 macro_rules! impl_sum {
     ($t:ident, $a:ty, $b:ty) => {
-        impl<$t: Field> Add<$b> for $a {
+        impl<$t: Field + 'static> Add<$b> for $a {
             type Output = Sum<$t>;
 
             fn add(self, rhs: $b) -> Self::Output {
@@ -1508,7 +1509,7 @@ macro_rules! impl_sum {
             }
         }
 
-        impl<$t: Field> Add<&$b> for &$a {
+        impl<$t: Field + 'static> Add<&$b> for &$a {
             type Output = <$a as Add<$b>>::Output;
 
             fn add(self, rhs: &$b) -> Self::Output {
@@ -1516,7 +1517,7 @@ macro_rules! impl_sum {
             }
         }
 
-        impl<$t: Field> Add<&$b> for $a {
+        impl<$t: Field + 'static> Add<&$b> for $a {
             type Output = <$a as Add<$b>>::Output;
 
             fn add(self, rhs: &$b) -> Self::Output {
@@ -1524,7 +1525,7 @@ macro_rules! impl_sum {
             }
         }
 
-        impl<$t: Field> Add<$b> for &$a {
+        impl<$t: Field + 'static> Add<$b> for &$a {
             type Output = <$a as Add<$b>>::Output;
 
             fn add(self, rhs: $b) -> Self::Output {
@@ -1532,7 +1533,7 @@ macro_rules! impl_sum {
             }
         }
 
-        impl<$t: Field> Add<$a> for $b {
+        impl<$t: Field + 'static> Add<$a> for $b {
             type Output = Sum<$t>;
 
             fn add(self, rhs: $a) -> Self::Output {
@@ -1540,7 +1541,7 @@ macro_rules! impl_sum {
             }
         }
 
-        impl<$t: Field> Add<&$a> for &$b {
+        impl<$t: Field + 'static> Add<&$a> for &$b {
             type Output = <$b as Add<$a>>::Output;
 
             fn add(self, rhs: &$a) -> Self::Output {
@@ -1548,7 +1549,7 @@ macro_rules! impl_sum {
             }
         }
 
-        impl<$t: Field> Add<&$a> for $b {
+        impl<$t: Field + 'static> Add<&$a> for $b {
             type Output = <$b as Add<$a>>::Output;
 
             fn add(self, rhs: &$a) -> Self::Output {
@@ -1556,7 +1557,7 @@ macro_rules! impl_sum {
             }
         }
 
-        impl<$t: Field> Add<$a> for &$b {
+        impl<$t: Field + 'static> Add<$a> for &$b {
             type Output = <$b as Add<$a>>::Output;
 
             fn add(self, rhs: $a) -> Self::Output {
@@ -1565,7 +1566,7 @@ macro_rules! impl_sum {
         }
     };
     ($t:ident, $a:ty) => {
-        impl<$t: Field> Add<$a> for $a {
+        impl<$t: Field + 'static> Add<$a> for $a {
             type Output = Sum<$t>;
 
             fn add(self, rhs: $a) -> Self::Output {
@@ -1573,7 +1574,7 @@ macro_rules! impl_sum {
             }
         }
 
-        impl<$t: Field> Add<&$a> for &$a {
+        impl<$t: Field + 'static> Add<&$a> for &$a {
             type Output = <$a as Add<$a>>::Output;
 
             fn add(self, rhs: &$a) -> Self::Output {
@@ -1581,7 +1582,7 @@ macro_rules! impl_sum {
             }
         }
 
-        impl<$t: Field> Add<&$a> for $a {
+        impl<$t: Field + 'static> Add<&$a> for $a {
             type Output = <$a as Add<$a>>::Output;
 
             fn add(self, rhs: &$a) -> Self::Output {
@@ -1589,7 +1590,7 @@ macro_rules! impl_sum {
             }
         }
 
-        impl<$t: Field> Add<$a> for &$a {
+        impl<$t: Field + 'static> Add<$a> for &$a {
             type Output = <$a as Add<$a>>::Output;
 
             fn add(self, rhs: $a) -> Self::Output {
@@ -1600,7 +1601,7 @@ macro_rules! impl_sum {
 }
 macro_rules! impl_appending_sum {
     ($t:ident, $a:ty) => {
-        impl<$t: Field> Add<Sum<$t>> for $a {
+        impl<$t: Field + 'static> Add<Sum<$t>> for $a {
             type Output = Sum<$t>;
 
             fn add(self, rhs: Sum<$t>) -> Self::Output {
@@ -1610,7 +1611,7 @@ macro_rules! impl_appending_sum {
             }
         }
 
-        impl<$t: Field> Add<$a> for Sum<$t> {
+        impl<$t: Field + 'static> Add<$a> for Sum<$t> {
             type Output = Sum<$t>;
 
             fn add(self, rhs: $a) -> Self::Output {
@@ -1620,7 +1621,7 @@ macro_rules! impl_appending_sum {
             }
         }
 
-        impl<$t: Field> Add<&Sum<$t>> for &$a {
+        impl<$t: Field + 'static> Add<&Sum<$t>> for &$a {
             type Output = <$a as Add<Sum<$t>>>::Output;
 
             fn add(self, rhs: &Sum<$t>) -> Self::Output {
@@ -1628,7 +1629,7 @@ macro_rules! impl_appending_sum {
             }
         }
 
-        impl<$t: Field> Add<&Sum<$t>> for $a {
+        impl<$t: Field + 'static> Add<&Sum<$t>> for $a {
             type Output = <$a as Add<Sum<$t>>>::Output;
 
             fn add(self, rhs: &Sum<$t>) -> Self::Output {
@@ -1636,7 +1637,7 @@ macro_rules! impl_appending_sum {
             }
         }
 
-        impl<$t: Field> Add<Sum<$t>> for &$a {
+        impl<$t: Field + 'static> Add<Sum<$t>> for &$a {
             type Output = <$a as Add<Sum<$t>>>::Output;
 
             fn add(self, rhs: Sum<$t>) -> Self::Output {
@@ -1644,7 +1645,7 @@ macro_rules! impl_appending_sum {
             }
         }
 
-        impl<$t: Field> Add<&$a> for &Sum<$t> {
+        impl<$t: Field + 'static> Add<&$a> for &Sum<$t> {
             type Output = <Sum<$t> as Add<$a>>::Output;
 
             fn add(self, rhs: &$a) -> Self::Output {
@@ -1652,7 +1653,7 @@ macro_rules! impl_appending_sum {
             }
         }
 
-        impl<$t: Field> Add<&$a> for Sum<$t> {
+        impl<$t: Field + 'static> Add<&$a> for Sum<$t> {
             type Output = <Sum<$t> as Add<$a>>::Output;
 
             fn add(self, rhs: &$a) -> Self::Output {
@@ -1660,7 +1661,7 @@ macro_rules! impl_appending_sum {
             }
         }
 
-        impl<$t: Field> Add<$a> for &Sum<$t> {
+        impl<$t: Field + 'static> Add<$a> for &Sum<$t> {
             type Output = <Sum<$t> as Add<$a>>::Output;
 
             fn add(self, rhs: $a) -> Self::Output {
@@ -1671,7 +1672,7 @@ macro_rules! impl_appending_sum {
 }
 macro_rules! impl_prod {
     ($t:ident, $a:ty, $b:ty) => {
-        impl<$t: Field> Mul<$b> for $a {
+        impl<$t: Field + 'static> Mul<$b> for $a {
             type Output = Product<$t>;
 
             fn mul(self, rhs: $b) -> Self::Output {
@@ -1692,7 +1693,7 @@ macro_rules! impl_prod {
             }
         }
 
-        impl<$t: Field> Mul<&$b> for &$a {
+        impl<$t: Field + 'static> Mul<&$b> for &$a {
             type Output = <$a as Mul<$b>>::Output;
 
             fn mul(self, rhs: &$b) -> Self::Output {
@@ -1700,7 +1701,7 @@ macro_rules! impl_prod {
             }
         }
 
-        impl<$t: Field> Mul<&$b> for $a {
+        impl<$t: Field + 'static> Mul<&$b> for $a {
             type Output = <$a as Mul<$b>>::Output;
 
             fn mul(self, rhs: &$b) -> Self::Output {
@@ -1708,7 +1709,7 @@ macro_rules! impl_prod {
             }
         }
 
-        impl<$t: Field> Mul<$b> for &$a {
+        impl<$t: Field + 'static> Mul<$b> for &$a {
             type Output = <$a as Mul<$b>>::Output;
 
             fn mul(self, rhs: $b) -> Self::Output {
@@ -1716,7 +1717,7 @@ macro_rules! impl_prod {
             }
         }
 
-        impl<$t: Field> Mul<$a> for $b {
+        impl<$t: Field + 'static> Mul<$a> for $b {
             type Output = Product<$t>;
 
             fn mul(self, rhs: $a) -> Self::Output {
@@ -1737,7 +1738,7 @@ macro_rules! impl_prod {
             }
         }
 
-        impl<$t: Field> Mul<&$a> for &$b {
+        impl<$t: Field + 'static> Mul<&$a> for &$b {
             type Output = <$b as Mul<$a>>::Output;
 
             fn mul(self, rhs: &$a) -> Self::Output {
@@ -1745,7 +1746,7 @@ macro_rules! impl_prod {
             }
         }
 
-        impl<$t: Field> Mul<&$a> for $b {
+        impl<$t: Field + 'static> Mul<&$a> for $b {
             type Output = <$b as Mul<$a>>::Output;
 
             fn mul(self, rhs: &$a) -> Self::Output {
@@ -1753,7 +1754,7 @@ macro_rules! impl_prod {
             }
         }
 
-        impl<$t: Field> Mul<$a> for &$b {
+        impl<$t: Field + 'static> Mul<$a> for &$b {
             type Output = <$b as Mul<$a>>::Output;
 
             fn mul(self, rhs: $a) -> Self::Output {
@@ -1762,7 +1763,7 @@ macro_rules! impl_prod {
         }
     };
     ($t:ident, $a:ty) => {
-        impl<$t: Field> Mul<$a> for $a {
+        impl<$t: Field + 'static> Mul<$a> for $a {
             type Output = Product<$t>;
 
             fn mul(self, rhs: $a) -> Self::Output {
@@ -1783,7 +1784,7 @@ macro_rules! impl_prod {
             }
         }
 
-        impl<$t: Field> Mul<&$a> for &$a {
+        impl<$t: Field + 'static> Mul<&$a> for &$a {
             type Output = <$a as Mul<$a>>::Output;
 
             fn mul(self, rhs: &$a) -> Self::Output {
@@ -1791,7 +1792,7 @@ macro_rules! impl_prod {
             }
         }
 
-        impl<$t: Field> Mul<&$a> for $a {
+        impl<$t: Field + 'static> Mul<&$a> for $a {
             type Output = <$a as Mul<$a>>::Output;
 
             fn mul(self, rhs: &$a) -> Self::Output {
@@ -1799,7 +1800,7 @@ macro_rules! impl_prod {
             }
         }
 
-        impl<$t: Field> Mul<$a> for &$a {
+        impl<$t: Field + 'static> Mul<$a> for &$a {
             type Output = <$a as Mul<$a>>::Output;
 
             fn mul(self, rhs: $a) -> Self::Output {
@@ -1810,7 +1811,7 @@ macro_rules! impl_prod {
 }
 macro_rules! impl_box_prod {
     ($t:ident, $a:ty) => {
-        impl<$t: Field> Mul<Box<dyn AmpLike<$t>>> for $a {
+        impl<$t: Field + 'static> Mul<Box<dyn AmpLike<$t>>> for $a {
             type Output = Product<$t>;
             fn mul(self, rhs: Box<dyn AmpLike<$t>>) -> Self::Output {
                 match (self.get_cloned_terms(), rhs.get_cloned_terms()) {
@@ -1829,7 +1830,7 @@ macro_rules! impl_box_prod {
                 }
             }
         }
-        impl<$t: Field> Mul<$a> for Box<dyn AmpLike<$t>> {
+        impl<$t: Field + 'static> Mul<$a> for Box<dyn AmpLike<$t>> {
             type Output = Product<$t>;
             fn mul(self, rhs: $a) -> Self::Output {
                 match (self.get_cloned_terms(), rhs.get_cloned_terms()) {
@@ -1852,7 +1853,7 @@ macro_rules! impl_box_prod {
 }
 macro_rules! impl_box_sum {
     ($t:ident, $a:ty) => {
-        impl<$t: Field> Add<Box<dyn AmpLike<$t>>> for $a {
+        impl<$t: Field + 'static> Add<Box<dyn AmpLike<$t>>> for $a {
             type Output = Sum<$t>;
             fn add(self, rhs: Box<dyn AmpLike<$t>>) -> Self::Output {
                 match (self.get_cloned_terms(), rhs.get_cloned_terms()) {
@@ -1871,7 +1872,7 @@ macro_rules! impl_box_sum {
                 }
             }
         }
-        impl<$t: Field> Add<$a> for Box<dyn AmpLike<$t>> {
+        impl<$t: Field + 'static> Add<$a> for Box<dyn AmpLike<$t>> {
             type Output = Sum<$t>;
             fn add(self, rhs: $a) -> Self::Output {
                 match (self.get_cloned_terms(), rhs.get_cloned_terms()) {
@@ -1894,7 +1895,7 @@ macro_rules! impl_box_sum {
 }
 macro_rules! impl_dist {
     ($t:ident, $a:ty) => {
-        impl<$t: Field> Mul<Sum<$t>> for $a {
+        impl<$t: Field + 'static> Mul<Sum<$t>> for $a {
             type Output = Sum<$t>;
 
             fn mul(self, rhs: Sum<$t>) -> Self::Output {
@@ -1906,7 +1907,7 @@ macro_rules! impl_dist {
             }
         }
 
-        impl<$t: Field> Mul<$a> for Sum<$t> {
+        impl<$t: Field + 'static> Mul<$a> for Sum<$t> {
             type Output = Sum<$t>;
 
             fn mul(self, rhs: $a) -> Self::Output {
@@ -1918,7 +1919,7 @@ macro_rules! impl_dist {
             }
         }
 
-        impl<$t: Field> Mul<&$a> for &Sum<$t> {
+        impl<$t: Field + 'static> Mul<&$a> for &Sum<$t> {
             type Output = <Sum<$t> as Mul<$a>>::Output;
 
             fn mul(self, rhs: &$a) -> Self::Output {
@@ -1926,7 +1927,7 @@ macro_rules! impl_dist {
             }
         }
 
-        impl<$t: Field> Mul<&$a> for Sum<$t> {
+        impl<$t: Field + 'static> Mul<&$a> for Sum<$t> {
             type Output = <Sum<$t> as Mul<$a>>::Output;
 
             fn mul(self, rhs: &$a) -> Self::Output {
@@ -1934,7 +1935,7 @@ macro_rules! impl_dist {
             }
         }
 
-        impl<$t: Field> Mul<$a> for &Sum<$t> {
+        impl<$t: Field + 'static> Mul<$a> for &Sum<$t> {
             type Output = <Sum<$t> as Mul<$a>>::Output;
 
             fn mul(self, rhs: $a) -> Self::Output {
@@ -1942,7 +1943,7 @@ macro_rules! impl_dist {
             }
         }
 
-        impl<$t: Field> Mul<&Sum<$t>> for &$a {
+        impl<$t: Field + 'static> Mul<&Sum<$t>> for &$a {
             type Output = <$a as Mul<Sum<$t>>>::Output;
 
             fn mul(self, rhs: &Sum<$t>) -> Self::Output {
@@ -1950,7 +1951,7 @@ macro_rules! impl_dist {
             }
         }
 
-        impl<$t: Field> Mul<&Sum<$t>> for $a {
+        impl<$t: Field + 'static> Mul<&Sum<$t>> for $a {
             type Output = <$a as Mul<Sum<$t>>>::Output;
 
             fn mul(self, rhs: &Sum<$t>) -> Self::Output {
@@ -1958,7 +1959,7 @@ macro_rules! impl_dist {
             }
         }
 
-        impl<$t: Field> Mul<Sum<$t>> for &$a {
+        impl<$t: Field + 'static> Mul<Sum<$t>> for &$a {
             type Output = <$a as Mul<Sum<$t>>>::Output;
 
             fn mul(self, rhs: Sum<$t>) -> Self::Output {

--- a/crates/rustitude-core/src/lib.rs
+++ b/crates/rustitude-core/src/lib.rs
@@ -68,7 +68,8 @@
 //! Because the beam is often directed along the $`z`$-axis, there is an alternative way to store
 //! the `EPS` vector without a new branch (for linear polarization. The $`x`$ and $`y`$ components
 //! of `EPS` can be stored as `Px_Beam` and `Py_Beam` respectively, and the format can be loaded
-//! using [`Dataset::from_parquet_eps_in_beam`](`crate::dataset::Dataset::from_parquet_eps_in_beam`).
+//! using [`Dataset::from_parquet`](`crate::dataset::Dataset::from_parquet`) with the
+//! [`ReadMethod::EPSInBeam`](`crate::dataset::ReadMethod::EPSInBeam`) method.
 //!
 //! # Creating a New Amplitude
 //!
@@ -181,17 +182,12 @@
 //! majority of an analysis in 32-bit mode, switching over to 64-bit mode when we actually get near
 //! a solution and want the increased accuracy!
 //!
-//! The [`Field`] trait contains a few helper constants and functions to make this easier for those
-//! who aren't as familiar with rust. Constants are provided for whole numbers between zero and ten
-//! (inclusively), and the [`Field`] trait also contains a few mathematical constants like
+//! The [`Field`] trait contains a few mathematical constants like
 //! [`Field::PI()`][`num::traits::FloatConst::PI()`] and
-//! [`Field::SQRT_2()`][`num::traits::FloatConst::SQRT_2()`]. Most mathematical functions are
-//! aliased with a leading "f" to simplify duplicated function definitions in the [`num::Float`]
-//! and [`nalgebra::RealField`] traits. For instance, [`Field::fabs()`] calls
-//! [`num::Float::abs()`], since the alternative would be to use the fully qualified name to
-//! distinguish it from [`nalgebra::ComplexField::abs()`].
+//! [`Field::SQRT_2()`][`num::traits::FloatConst::SQRT_2()`] as well as traits which
+//! implement most standard mathematical functions. See the [`Float`] trait for more details.
 //!
-//! # Combining Amplitudes into Models
+//! //! # Combining Amplitudes into Models
 //! We can use several operations to modify and combine amplitudes. Since amplitudes yield complex
 //! values, the following convenience methods are provided:
 //! [`real`](`amplitude::AmpLike::real`), and [`imag`](`amplitude::AmpLike::imag`) give the real and

--- a/crates/rustitude-core/src/lib.rs
+++ b/crates/rustitude-core/src/lib.rs
@@ -361,6 +361,15 @@
     missing_docs
 )]
 #![allow(deprecated)]
+
+use std::fmt::{Debug, Display};
+use std::iter::{Product, Sum};
+
+use nalgebra::Vector3;
+use num::{
+    traits::{FloatConst, NumAssignOps},
+    Float, FromPrimitive,
+};
 pub mod amplitude;
 pub mod dataset;
 pub mod four_momentum;
@@ -375,320 +384,71 @@ pub mod prelude {
     pub use crate::errors::RustitudeError;
     pub use crate::four_momentum::FourMomentum;
     pub use crate::manager::{ExtendedLogLikelihood, Manager};
-    pub use crate::{model, Field};
-    // pub use crate::{constants::*, ComplexField, Field};
-    pub use nalgebra::{ComplexField, RealField, Vector3};
+    pub use crate::{convert, convert_array, convert_vec, model, Field, UnitVector};
+    pub use nalgebra::Vector3;
     pub use num::Complex;
 }
 
-/// A trait which describes a field of "Real" numbers which can be used in calculating amplitudes.
+/// A trait representing a numeric field which can be used in calculating amplitudes.
 pub trait Field:
-    nalgebra::RealField
-    + std::iter::Sum
-    + std::iter::Product
-    + Copy
-    + Clone
+    Float
+    + Sum
+    + Product
+    + FloatConst
+    + NumAssignOps
+    + Debug
+    + Display
     + Default
-    + ganesh::core::Field
-    + num::Float
-    + num::traits::FloatConst
+    + Send
+    + Sync
+    + FromPrimitive
 {
-    /// See [`f64::MIN_POSITIVE`]
-    const MIN_POSITIVE: Self;
-    /// See [`f64::MAX`]
-    const MAX: Self;
-    /// See [`f64::MIN`]
-    const MIN: Self;
-    /// See [`f64::INFINITY`]
-    const INFINITY: Self;
-    /// See [`f64::NEG_INFINITY`]
-    const NEG_INFINITY: Self;
-    /// Alias for 0.0
-    const ZERO: Self;
-    /// Alias for 1.0
-    const ONE: Self;
-    /// Alias for 2.0
-    const TWO: Self;
-    /// Alias for 3.0
-    const THREE: Self;
-    /// Alias for 4.0
-    const FOUR: Self;
-    /// Alias for 5.0
-    const FIVE: Self;
-    /// Alias for 6.0
-    const SIX: Self;
-    /// Alias for 7.0
-    const SEVEN: Self;
-    /// Alias for 8.0
-    const EIGHT: Self;
-    /// Alias for 9.0
-    const NINE: Self;
-    /// Alias for 10.0
-    const TEN: Self;
-    ///Alias for the imaginary constant
-    const I: num::Complex<Self>;
-    /// Shorthand to convert an `f64` into a [`Field`].
-    /// See also: [`Field::convert_f64`].
-    fn f(x: f64) -> Self {
-        Self::convert_f64(x)
-    }
-    /// Shorthand to convert a [`Vec<f64>`] into a [`Vec<Field>`].
-    /// See also: [`Field::convert_vec_f64`].
-    fn fv(x: Vec<f64>) -> Vec<Self> {
-        Self::convert_vec_f64(x)
-    }
-    /// Shorthand to convert a `[f64; N]` into a `[Field; N]`.
-    /// See also: [`Field::convert_array_f64`].
-    fn fa<const N: usize>(x: [f64; N]) -> [Self; N] {
-        Self::convert_array_f64(x)
-    }
-    /// Converts a `[f64; N]` into a `[Field; N]`.
-    fn convert_array_f64<const N: usize>(x: [f64; N]) -> [Self; N] {
-        std::array::from_fn(|i| Self::convert_f64(x[i]))
-    }
-    /// Converts a [`Vec<f64>`] into a [`Vec<Field>`].
-    fn convert_vec_f64(x: Vec<f64>) -> Vec<Self> {
-        x.into_iter().map(Self::f).collect()
-    }
-    /// Converts an `f64` into a [`Field`].
-    fn convert_f64(x: f64) -> Self;
-    /// Converts an `f32` into a [`Field`].
-    fn convert_f32(x: f32) -> Self;
-    /// Converts a `usize` into a [`Field`].
-    fn convert_usize(x: usize) -> Self;
-    /// Converts an `isize` into a [`Field`].
-    fn convert_isize(x: isize) -> Self;
-    /// Converts a `u32` into a [`Field`].
-    fn convert_u32(x: u32) -> Self;
-    /// Converts a [`Field`] into the real part of a [`Complex<Field>`].
-    fn c(self) -> num::Complex<Self> {
-        num::Complex::from(self)
-    }
-    /// Shorthand for [`num::Complex::i`].
-    fn i() -> num::Complex<Self> {
-        Field::I
-    }
-    /// Shorthand for [`num::Float::abs`].
-    fn fabs(self) -> Self {
-        num::Float::abs(self)
-    }
-    /// Shorthand for [`num::Float::sqrt`].
-    fn fsqrt(self) -> Self {
-        num::Float::sqrt(self)
-    }
-    /// Shorthand for [`num::Float::cbrt`].
-    fn fcbrt(self) -> Self {
-        num::Float::cbrt(self)
-    }
-    /// Shorthand for [`num::Float::powi`].
-    fn fpowi(self, n: i32) -> Self {
-        num::Float::powi(self, n)
-    }
-    /// Shorthand for [`num::Float::powf`].
-    fn fpowf(self, n: Self) -> Self {
-        num::Float::powf(self, n)
-    }
-    /// Shorthand for [`num::Float::sin`].
-    fn fsin(self) -> Self {
-        num::Float::sin(self)
-    }
-    /// Shorthand for [`num::Float::cos`].
-    fn fcos(self) -> Self {
-        num::Float::cos(self)
-    }
-    /// Shorthand for [`num::Float::tan`].
-    fn ftan(self) -> Self {
-        num::Float::tan(self)
-    }
-    /// Shorthand for [`num::Float::asin`].
-    fn fasin(self) -> Self {
-        num::Float::asin(self)
-    }
-    /// Shorthand for [`num::Float::acos`].
-    fn facos(self) -> Self {
-        num::Float::acos(self)
-    }
-    /// Shorthand for [`num::Float::atan`].
-    fn fatan(self) -> Self {
-        num::Float::atan(self)
-    }
-    /// Shorthand for [`nalgebra::RealField::atan2`].
-    fn fatan2(self, other: Self) -> Self {
-        nalgebra::RealField::atan2(self, other)
-    }
-    /// Shorthand for [`num::Float::sinh`].
-    fn fsinh(self) -> Self {
-        num::Float::sinh(self)
-    }
-    /// Shorthand for [`num::Float::cosh`].
-    fn fcosh(self) -> Self {
-        num::Float::cosh(self)
-    }
-    /// Shorthand for [`num::Float::tanh`].
-    fn ftanh(self) -> Self {
-        num::Float::tanh(self)
-    }
-    /// Shorthand for [`num::Float::asinh`].
-    fn fasinh(self) -> Self {
-        num::Float::asinh(self)
-    }
-    /// Shorthand for [`num::Float::acosh`].
-    fn facosh(self) -> Self {
-        num::Float::acosh(self)
-    }
-    /// Shorthand for [`num::Float::atanh`].
-    fn fatanh(self) -> Self {
-        num::Float::atanh(self)
-    }
-    /// Shorthand for [`num::Float::log`].
-    fn flog(self, base: Self) -> Self {
-        num::Float::log(self, base)
-    }
-    /// Shorthand for [`num::Float::log2`].
-    fn flog2(self) -> Self {
-        num::Float::log2(self)
-    }
-    /// Shorthand for [`num::Float::log10`].
-    fn flog10(self) -> Self {
-        num::Float::log10(self)
-    }
-    /// Shorthand for [`num::Float::ln`].
-    fn fln(self) -> Self {
-        num::Float::ln(self)
-    }
-    /// Shorthand for [`num::Float::ln_1p`].
-    fn fln_1p(self) -> Self {
-        num::Float::ln_1p(self)
-    }
-    /// Shorthand for [`num::Float::exp`].
-    fn fexp(self) -> Self {
-        num::Float::exp(self)
-    }
-    /// Shorthand for [`num::Float::exp2`].
-    fn fexp2(self) -> Self {
-        num::Float::exp2(self)
-    }
-    /// Shorthand for [`num::Float::exp_m1`].
-    fn fexp_m1(self) -> Self {
-        num::Float::exp_m1(self)
-    }
-    /// Shorthand for [`num::Float::hypot`].
-    fn fhypot(self, other: Self) -> Self {
-        num::Float::hypot(self, other)
-    }
-    /// Shorthand for [`num::Float::recip`].
-    fn frecip(self) -> Self {
-        num::Float::recip(self)
-    }
-    /// Shorthand for [`num::Float::mul_add`].
-    fn fmul_add(self, a: Self, b: Self) -> Self {
-        num::Float::mul_add(self, a, b)
-    }
-    /// Shorthand for [`num::Float::floor`].
-    fn ffloor(self) -> Self {
-        num::Float::floor(self)
-    }
-    /// Shorthand for [`num::Float::ceil`].
-    fn fceil(self) -> Self {
-        num::Float::ceil(self)
-    }
-    /// Shorthand for [`num::Float::round`].
-    fn fround(self) -> Self {
-        num::Float::round(self)
-    }
-    /// Shorthand for [`num::Float::trunc`].
-    fn ftrunc(self) -> Self {
-        num::Float::trunc(self)
-    }
-    /// Shorthand for [`num::Float::fract`].
-    fn ffract(self) -> Self {
-        num::Float::fract(self)
-    }
-    /// Shorthand for [`num::Float::min`].
-    fn fmin(self, other: Self) -> Self {
-        num::Float::min(self, other)
-    }
-    /// Shorthand for [`num::Float::max`].
-    fn fmax(self, other: Self) -> Self {
-        num::Float::max(self, other)
-    }
+}
+impl Field for f64 {}
+impl Field for f32 {}
+
+#[macro_export]
+/// Convenience macro for converting raw numeric values to a generic.
+macro_rules! convert {
+    ($value:expr, $type:ty) => {{
+        #[allow(clippy::unwrap_used)]
+        <$type as num::NumCast>::from($value).unwrap()
+    }};
 }
 
-impl Field for f64 {
-    const MIN_POSITIVE: Self = Self::MIN_POSITIVE;
-    const MAX: Self = Self::MAX;
-    const MIN: Self = Self::MIN;
-    const INFINITY: Self = Self::INFINITY;
-    const NEG_INFINITY: Self = Self::NEG_INFINITY;
-    const ZERO: Self = 0.0;
-    const ONE: Self = 1.0;
-    const TWO: Self = 2.0;
-    const THREE: Self = 3.0;
-    const FOUR: Self = 4.0;
-    const FIVE: Self = 5.0;
-    const SIX: Self = 6.0;
-    const SEVEN: Self = 7.0;
-    const EIGHT: Self = 8.0;
-    const NINE: Self = 9.0;
-    const TEN: Self = 10.0;
-    const I: num::Complex<Self> = num::Complex::<Self>::I;
-
-    fn convert_f64(x: f64) -> Self {
-        x
-    }
-
-    fn convert_f32(x: f32) -> Self {
-        x as Self
-    }
-
-    fn convert_usize(x: usize) -> Self {
-        x as Self
-    }
-
-    fn convert_isize(x: isize) -> Self {
-        x as Self
-    }
-    fn convert_u32(x: u32) -> Self {
-        x as Self
-    }
+#[macro_export]
+/// Convenience macro for converting a raw numeric [`Vec`] to a generic [`Vec`].
+macro_rules! convert_vec {
+    ($vec:expr, $type:ty) => {{
+        $vec.into_iter()
+            .map(|value| $crate::convert!(value, $type))
+            .collect::<Vec<$type>>()
+    }};
 }
-impl Field for f32 {
-    const MIN_POSITIVE: Self = Self::MIN_POSITIVE;
-    const MAX: Self = Self::MAX;
-    const MIN: Self = Self::MIN;
-    const INFINITY: Self = Self::INFINITY;
-    const NEG_INFINITY: Self = Self::NEG_INFINITY;
-    const ZERO: Self = 0.0;
-    const ONE: Self = 1.0;
-    const TWO: Self = 2.0;
-    const THREE: Self = 3.0;
-    const FOUR: Self = 4.0;
-    const FIVE: Self = 5.0;
-    const SIX: Self = 6.0;
-    const SEVEN: Self = 7.0;
-    const EIGHT: Self = 8.0;
-    const NINE: Self = 9.0;
-    const TEN: Self = 10.0;
-    const I: num::Complex<Self> = num::Complex::<Self>::I;
 
-    fn convert_f64(x: f64) -> Self {
-        x as Self
-    }
+#[macro_export]
+/// Convenience macro for converting a raw numeric array to a generic array.
+macro_rules! convert_array {
+    ($arr:expr, $type:ty) => {{
+        let temp_vec: Vec<_> = $arr
+            .iter()
+            .map(|&value| $crate::convert!(value, $type))
+            .collect();
+        #[allow(clippy::unwrap_used)]
+        temp_vec.try_into().unwrap()
+    }};
+}
 
-    fn convert_f32(x: f32) -> Self {
-        x
-    }
+/// A trait to normalize structs (mostly to use on nalgebra vectors without needing [`nalgebra::RealField`])
+pub trait UnitVector {
+    /// Returns a normalized form of the input.
+    fn unit(&self) -> Self;
+}
 
-    fn convert_usize(x: usize) -> Self {
-        x as Self
-    }
-
-    fn convert_isize(x: isize) -> Self {
-        x as Self
-    }
-
-    fn convert_u32(x: u32) -> Self {
-        x as Self
+impl<F: Field + 'static> UnitVector for Vector3<F> {
+    fn unit(&self) -> Self {
+        let mag = F::sqrt(self.x * self.x + self.y * self.y + self.z * self.z);
+        self / mag
     }
 }
 
@@ -1036,15 +796,15 @@ pub mod utils {
     /// Checks if two floating point numbers are essentially equal.
     /// See [https://floating-point-gui.de/errors/comparison/](https://floating-point-gui.de/errors/comparison/).
     pub fn is_close<F: Field>(a: F, b: F, epsilon: F) -> bool {
-        let abs_a = F::fabs(a);
-        let abs_b = F::fabs(b);
-        let diff = F::fabs(a - b);
+        let abs_a = F::abs(a);
+        let abs_b = F::abs(b);
+        let diff = F::abs(a - b);
         if a == b {
             true
-        } else if a == F::ZERO || b == F::ZERO || (abs_a + abs_b < F::MIN_POSITIVE) {
-            diff < (epsilon * F::MIN_POSITIVE)
+        } else if a == F::zero() || b == F::zero() || (abs_a + abs_b < F::min_positive_value()) {
+            diff < (epsilon * F::min_positive_value())
         } else {
-            diff / F::fmin(abs_a + abs_b, F::MAX) < epsilon
+            diff / F::min(abs_a + abs_b, F::max_value()) < epsilon
         }
     }
 

--- a/crates/rustitude-core/src/manager.rs
+++ b/crates/rustitude-core/src/manager.rs
@@ -5,7 +5,7 @@
 
 use std::fmt::{Debug, Display};
 
-use ganesh::prelude::Function;
+use ganesh::prelude::{DVector, Function};
 use rayon::prelude::*;
 
 use crate::{
@@ -901,7 +901,7 @@ impl<F: Field> ExtendedLogLikelihood<F> {
 }
 
 impl<F: Field + ganesh::core::Field> Function<F, (), RustitudeError> for ExtendedLogLikelihood<F> {
-    fn evaluate(&self, x: &[F], _args: Option<&()>) -> Result<F, RustitudeError> {
-        self.par_evaluate(x)
+    fn evaluate(&self, x: &DVector<F>, _args: Option<&()>) -> Result<F, RustitudeError> {
+        self.par_evaluate(x.as_slice())
     }
 }

--- a/crates/rustitude-core/src/manager.rs
+++ b/crates/rustitude-core/src/manager.rs
@@ -9,6 +9,7 @@ use ganesh::prelude::Function;
 use rayon::prelude::*;
 
 use crate::{
+    convert,
     errors::RustitudeError,
     prelude::{Amplitude, Dataset, Event, Model, Parameter},
     Field,
@@ -17,7 +18,7 @@ use crate::{
 /// The [`Manager`] struct links a [`Model`] to a [`Dataset`] and provides methods to manipulate
 /// the [`Model`] and evaluate it over the [`Dataset`].
 #[derive(Clone)]
-pub struct Manager<F: Field> {
+pub struct Manager<F: Field + 'static> {
     /// The associated [`Model`].
     pub model: Model<F>,
     /// The associated [`Dataset`].
@@ -364,7 +365,7 @@ impl<F: Field> Manager<F> {
 /// dataset used for acceptance correction. These should probably have the same [`Manager`] in
 /// practice, but this is left to the user.
 #[derive(Clone)]
-pub struct ExtendedLogLikelihood<F: Field> {
+pub struct ExtendedLogLikelihood<F: Field + 'static> {
     /// [`Manager`] for data
     pub data_manager: Manager<F>,
     /// [`Manager`] for Monte-Carlo
@@ -410,7 +411,7 @@ impl<F: Field> ExtendedLogLikelihood<F> {
         let ln_l = (data_res
             .iter()
             .zip(data_weights)
-            .map(|(l, w)| w * F::fln(*l))
+            .map(|(l, w)| w * F::ln(*l))
             .sum::<F>())
             - (n_data / n_mc)
                 * (mc_norm_int
@@ -418,7 +419,7 @@ impl<F: Field> ExtendedLogLikelihood<F> {
                     .zip(mc_weights)
                     .map(|(l, w)| w * *l)
                     .sum::<F>());
-        Ok(F::convert_f64(-2.0) * ln_l)
+        Ok(convert!(-2, F) * ln_l)
     }
 
     /// Evaluate the [`ExtendedLogLikelihood`] over the [`Dataset`] with the given free parameters.
@@ -449,7 +450,7 @@ impl<F: Field> ExtendedLogLikelihood<F> {
         let ln_l = (data_res
             .iter()
             .zip(data_weights)
-            .map(|(l, w)| w * F::fln(*l))
+            .map(|(l, w)| w * F::ln(*l))
             .sum::<F>())
             - (n_data / n_mc)
                 * (mc_norm_int
@@ -457,7 +458,7 @@ impl<F: Field> ExtendedLogLikelihood<F> {
                     .zip(mc_weights)
                     .map(|(l, w)| w * *l)
                     .sum::<F>());
-        Ok(F::convert_f64(-2.0) * ln_l)
+        Ok(convert!(-2, F) * ln_l)
     }
 
     /// Evaluate the [`ExtendedLogLikelihood`] over the [`Dataset`] with the given free parameters.
@@ -488,7 +489,7 @@ impl<F: Field> ExtendedLogLikelihood<F> {
         let ln_l = (data_res
             .par_iter()
             .zip(data_weights)
-            .map(|(l, w)| w * F::fln(*l))
+            .map(|(l, w)| w * F::ln(*l))
             .sum::<F>())
             - (n_data / n_mc)
                 * (mc_norm_int
@@ -496,7 +497,7 @@ impl<F: Field> ExtendedLogLikelihood<F> {
                     .zip(mc_weights)
                     .map(|(l, w)| w * *l)
                     .sum::<F>());
-        Ok(F::convert_f64(-2.0) * ln_l)
+        Ok(convert!(-2, F) * ln_l)
     }
 
     /// Evaluate the [`ExtendedLogLikelihood`] over the [`Dataset`] with the given free parameters.
@@ -540,7 +541,7 @@ impl<F: Field> ExtendedLogLikelihood<F> {
         let ln_l = (data_res
             .par_iter()
             .zip(data_weights)
-            .map(|(l, w)| w * F::fln(*l))
+            .map(|(l, w)| w * F::ln(*l))
             .sum::<F>())
             - (n_data / n_mc)
                 * (mc_norm_int
@@ -548,7 +549,7 @@ impl<F: Field> ExtendedLogLikelihood<F> {
                     .zip(mc_weights)
                     .map(|(l, w)| w * *l)
                     .sum::<F>());
-        Ok(F::convert_f64(-2.0) * ln_l)
+        Ok(convert!(-2, F) * ln_l)
     }
 
     /// Evaluate the normalized intensity function over the given Monte-Carlo [`Dataset`] with the
@@ -899,7 +900,7 @@ impl<F: Field> ExtendedLogLikelihood<F> {
     }
 }
 
-impl<F: Field> Function<F, (), RustitudeError> for ExtendedLogLikelihood<F> {
+impl<F: Field + ganesh::core::Field> Function<F, (), RustitudeError> for ExtendedLogLikelihood<F> {
     fn evaluate(&self, x: &[F], _args: Option<&()>) -> Result<F, RustitudeError> {
         self.par_evaluate(x)
     }

--- a/crates/rustitude-gluex/src/dalitz.rs
+++ b/crates/rustitude-gluex/src/dalitz.rs
@@ -1,5 +1,5 @@
 use rayon::prelude::*;
-use rustitude_core::prelude::*;
+use rustitude_core::{convert, prelude::*};
 
 use crate::utils::Decay;
 
@@ -38,22 +38,25 @@ impl<F: Field> Node<F> for OmegaDalitz<F> {
                 let dalitz_t = (pip + pi0).m2();
                 let dalitz_u = (pim + pi0).m2();
 
-                let m3pi = (F::TWO * pip.m()) + pi0.m();
-                let dalitz_d = F::TWO * omega.m() * (omega.m() - m3pi);
-                let dalitz_sc = (F::ONE / F::THREE) * (omega.m2() + pip.m2() + pim.m2() + pi0.m2());
-                let dalitz_x = F::fsqrt(F::THREE) * (dalitz_t - dalitz_u) / dalitz_d;
-                let dalitz_y = F::THREE * (dalitz_sc - dalitz_s) / dalitz_d;
+                let m3pi = (convert!(2.0, F) * pip.m()) + pi0.m();
+                let dalitz_d = convert!(2.0, F) * omega.m() * (omega.m() - m3pi);
+                let dalitz_sc =
+                    (F::one() / convert!(3.0, F)) * (omega.m2() + pip.m2() + pim.m2() + pi0.m2());
+                let dalitz_x = F::sqrt(convert!(3.0, F)) * (dalitz_t - dalitz_u) / dalitz_d;
+                let dalitz_y = convert!(3.0, F) * (dalitz_sc - dalitz_s) / dalitz_d;
 
                 let dalitz_z = dalitz_x * dalitz_x + dalitz_y * dalitz_y;
-                let dalitz_sin3theta = F::fsin(F::THREE * F::fasin(dalitz_y / F::fsqrt(dalitz_z)));
+                let dalitz_sin3theta =
+                    F::sin(convert!(3.0, F) * F::asin(dalitz_y / F::sqrt(dalitz_z)));
 
                 let pip_omega = pip.boost_along(&omega);
                 let pim_omega = pim.boost_along(&omega);
                 let pi_cross = pip_omega.momentum().cross(&pim_omega.momentum());
 
-                let lambda = (F::FOUR / F::THREE) * F::fabs(pi_cross.dot(&pi_cross))
-                    / ((F::ONE / F::NINE)
-                        * (omega.m2() - (F::TWO * pip.m() + pi0.m()).fpowi(2)).fpowi(2));
+                let lambda = (convert!(4.0, F) / convert!(3.0, F))
+                    * F::abs(pi_cross.dot(&pi_cross))
+                    / ((F::one() / convert!(9.0, F))
+                        * (omega.m2() - (convert!(2.0, F) * pip.m() + pi0.m()).powi(2)).powi(2));
 
                 (dalitz_z, (dalitz_sin3theta, lambda))
             })
@@ -69,13 +72,19 @@ impl<F: Field> Node<F> for OmegaDalitz<F> {
         let beta = parameters[1];
         let gamma = parameters[2];
         let delta = parameters[3];
-        Ok(F::fsqrt(F::fabs(
+        Ok(F::sqrt(F::abs(
             lambda
-                * (F::ONE
-                    + F::TWO * alpha * dalitz_z
-                    + F::TWO * beta * dalitz_z.fpowf(F::THREE / F::TWO) * dalitz_sin3theta
-                    + F::TWO * gamma * dalitz_z.fpowi(2)
-                    + F::TWO * delta * dalitz_z.fpowf(F::FIVE / F::TWO) * dalitz_sin3theta),
+                * (F::one()
+                    + convert!(2.0, F) * alpha * dalitz_z
+                    + convert!(2.0, F)
+                        * beta
+                        * dalitz_z.powf(convert!(3.0, F) / convert!(2.0, F))
+                        * dalitz_sin3theta
+                    + convert!(2.0, F) * gamma * dalitz_z.powi(2)
+                    + convert!(2.0, F)
+                        * delta
+                        * dalitz_z.powf(convert!(5.0, F) / convert!(2.0, F))
+                        * dalitz_sin3theta),
         ))
         .into())
     }

--- a/crates/rustitude-gluex/src/polarization.rs
+++ b/crates/rustitude-gluex/src/polarization.rs
@@ -122,7 +122,7 @@ impl<F: Field> Node<F> for ThreePiPolFrac<F> {
                             ),
                             F
                         );
-                        term += ylm * Complex::from(neg_res_hel_prod * cg_neg + cg_pos);
+                        term += ylm * neg_res_hel_prod * cg_neg + cg_pos;
                     }
                     let ylm = ComplexSH::Spherical.eval(
                         self.l_resonance as i64,

--- a/crates/rustitude-gluex/src/polarization.rs
+++ b/crates/rustitude-gluex/src/polarization.rs
@@ -1,6 +1,6 @@
 use crate::utils::{self, Decay, Frame, Sign};
 use rayon::prelude::*;
-use rustitude_core::prelude::*;
+use rustitude_core::{convert, prelude::*};
 use sphrs::{ComplexSH, SHEval};
 
 #[derive(Clone)]
@@ -35,13 +35,13 @@ impl<F: Field> ThreePiPolFrac<F> {
         match (decay_resonance, decay_isobar) {
             (Decay::ThreeBodyDecay(_), Decay::TwoBodyDecay(_)) => Self {
                 beam_pol: match beam_pol {
-                    Sign::Positive => F::ONE,
-                    Sign::Negative => -F::ONE,
+                    Sign::Positive => F::one(),
+                    Sign::Negative => -F::one(),
                 },
                 j_resonance,
                 p_resonance: match p_resonance {
-                    Sign::Positive => F::ONE,
-                    Sign::Negative => -F::ONE,
+                    Sign::Positive => F::one(),
+                    Sign::Negative => -F::one(),
                 },
                 i_resonance,
                 l_resonance,
@@ -59,7 +59,7 @@ impl<F: Field> ThreePiPolFrac<F> {
 
 impl<F: Field> Node<F> for ThreePiPolFrac<F> {
     fn calculate(&self, parameters: &[F], event: &Event<F>) -> Result<Complex<F>, RustitudeError> {
-        Ok(self.data[event.index] * (F::ONE + self.beam_pol * parameters[0]) / F::FOUR)
+        Ok(self.data[event.index] * (F::one() + self.beam_pol * parameters[0]) / convert!(4, F))
     }
 
     fn precalculate(&mut self, dataset: &Dataset<F>) -> Result<(), RustitudeError> {
@@ -85,37 +85,44 @@ impl<F: Field> Node<F> for ThreePiPolFrac<F> {
                     self.decay_isobar.primary_p4(event).m(),
                     self.decay_isobar.secondary_p4(event).m(),
                 );
-                let neg_res_hel_prod =
-                    Complex::new(F::fcos(F::TWO * alpha), F::fsin(F::TWO * alpha))
-                        * self.beam_pol
-                        * self.p_resonance
-                        * (F::convert_u32((self.j_resonance % 2) * 2) / F::TWO);
-                let mut res = F::ZERO.c();
+                let neg_res_hel_prod = Complex::new(
+                    F::cos(convert!(2, F) * alpha),
+                    F::sin(convert!(2, F) * alpha),
+                ) * self.beam_pol
+                    * self.p_resonance
+                    * convert!(self.j_resonance % 2, F);
+                let mut res = Complex::default();
                 for m_res in -(self.l_resonance as isize)..(self.l_resonance as isize) {
-                    let mut term = F::ZERO.c();
+                    let mut term = Complex::default();
                     for m_iso in -(self.j_isobar as isize)..(self.j_isobar as isize) {
                         let ylm = ComplexSH::Spherical.eval(
                             self.j_isobar as i64,
                             m_iso as i64,
                             &p1_iso_coords,
                         );
-                        let cg_neg = F::f(wigners::clebsch_gordan(
-                            self.j_isobar,
-                            self.l_resonance as i32,
-                            m_iso as u32,
-                            m_res as i32,
-                            self.j_resonance,
-                            -1,
-                        ));
-                        let cg_pos = F::f(wigners::clebsch_gordan(
-                            self.j_isobar,
-                            self.l_resonance as i32,
-                            m_iso as u32,
-                            m_res as i32,
-                            self.j_resonance,
-                            1,
-                        ));
-                        term += ylm * (neg_res_hel_prod * cg_neg + cg_pos);
+                        let cg_neg = convert!(
+                            wigners::clebsch_gordan(
+                                self.j_isobar,
+                                self.l_resonance as i32,
+                                m_iso as u32,
+                                m_res as i32,
+                                self.j_resonance,
+                                -1,
+                            ),
+                            F
+                        );
+                        let cg_pos = convert!(
+                            wigners::clebsch_gordan(
+                                self.j_isobar,
+                                self.l_resonance as i32,
+                                m_iso as u32,
+                                m_res as i32,
+                                self.j_resonance,
+                                1,
+                            ),
+                            F
+                        );
+                        term += ylm * Complex::from(neg_res_hel_prod * cg_neg + cg_pos);
                     }
                     let ylm = ComplexSH::Spherical.eval(
                         self.l_resonance as i64,
@@ -125,7 +132,7 @@ impl<F: Field> Node<F> for ThreePiPolFrac<F> {
                     term *= ylm;
                     res += term;
                 }
-                res *= F::f(
+                res *= convert!(
                     wigners::clebsch_gordan(
                         1,
                         1,
@@ -141,8 +148,9 @@ impl<F: Field> Node<F> for ThreePiPolFrac<F> {
                         self.i_resonance as u32,
                         (self.iz_daughters[0] + self.iz_daughters[1] + self.iz_daughters[2]) as i32,
                     ),
-                ) * k.fpowi(self.l_resonance as i32)
-                    * q.fpowi(self.j_isobar as i32);
+                    F
+                ) * k.powi(self.l_resonance as i32)
+                    * q.powi(self.j_isobar as i32);
                 res
             })
             .collect();

--- a/crates/rustitude-gluex/src/resonances.rs
+++ b/crates/rustitude-gluex/src/resonances.rs
@@ -1,9 +1,9 @@
 use crate::utils;
 use crate::utils::Decay;
 
-use nalgebra::{SMatrix, SVector};
+use nalgebra::{RealField, SMatrix, SVector};
 use rayon::prelude::*;
-use rustitude_core::prelude::*;
+use rustitude_core::{convert, convert_array, convert_vec, prelude::*};
 
 #[derive(Default, Clone)]
 pub struct BreitWigner<F: Field> {
@@ -53,9 +53,9 @@ impl<F: Field> Node<F> for BreitWigner<F> {
         let g0 = parameters[1];
         let f0 = utils::blatt_weisskopf(m0, m1, m2, self.l);
         let q0 = utils::breakup_momentum(m0, m1, m2);
-        let g = g0 * (m0 / m) * (q / q0) * (f.fpowi(2) / f0.fpowi(2));
-        Ok(Complex::new(f * (m0 * g0 / F::PI()), F::ZERO)
-            / Complex::new(m0.fpowi(2) - m.fpowi(2), -F::ONE * m0 * g))
+        let g = g0 * (m0 / m) * (q / q0) * (f.powi(2) / f0.powi(2));
+        Ok(Complex::new(f * (m0 * g0 / F::PI()), F::zero())
+            / Complex::new(m0.powi(2) - m.powi(2), -F::one() * m0 * g))
     }
 
     fn parameters(&self) -> Vec<String> {
@@ -98,9 +98,9 @@ impl<F: Field> Node<F> for Flatte<F> {
             .map(|event| {
                 let res_mass = self.decay.resonance_p4(event).m();
                 let br_mom_channel_1 =
-                    utils::breakup_momentum_c(F::fsqrt(res_mass), self.m1s[0], self.m1s[1]);
+                    utils::breakup_momentum_c(F::sqrt(res_mass), self.m1s[0], self.m1s[1]);
                 let br_mom_channel_2 =
-                    utils::breakup_momentum_c(F::fsqrt(res_mass), self.m2s[0], self.m2s[1]);
+                    utils::breakup_momentum_c(F::sqrt(res_mass), self.m2s[0], self.m2s[1]);
                 (res_mass, [br_mom_channel_1, br_mom_channel_2])
             })
             .collect();
@@ -114,16 +114,15 @@ impl<F: Field> Node<F> for Flatte<F> {
     fn calculate(&self, parameters: &[F], event: &Event<F>) -> Result<Complex<F>, RustitudeError> {
         let (res_mass, br_momenta) = self.data[event.index];
         let gammas = [
-            parameters[1].c() * br_momenta[0],
-            parameters[2].c() * br_momenta[1],
+            Complex::from(parameters[1]) * br_momenta[0],
+            Complex::from(parameters[2]) * br_momenta[1],
         ];
         let gamma_low = gammas[self.low_channel];
         let gamma_j = gammas[self.channel];
-        let mass = parameters[0].c();
-        Ok(
-            (mass * Complex::sqrt(gamma_low * gamma_j)) / (mass.powi(2) - res_mass.fpowi(2).c())
-                - F::I * mass * (gammas[0] * gammas[1]),
-        )
+        let mass = Complex::from(parameters[0]);
+        Ok((mass * Complex::sqrt(gamma_low * gamma_j))
+            / (mass.powi(2) - Complex::from(res_mass.powi(2)))
+            - Complex::<F>::i() * mass * (gammas[0] * gammas[1]))
     }
 }
 
@@ -143,7 +142,7 @@ pub struct KMatrixConstants<F: Field, const C: usize, const R: usize> {
     l: usize,
 }
 
-impl<F: Field, const C: usize, const R: usize> KMatrixConstants<F, C, R> {
+impl<F: Field + 'static, const C: usize, const R: usize> KMatrixConstants<F, C, R> {
     fn c_matrix(&self, s: F) -> SMatrix<Complex<F>, C, C> {
         SMatrix::from_diagonal(&SVector::from_fn(|i, _| {
             utils::rho(s, self.m1s[i], self.m2s[i]) / F::PI()
@@ -154,11 +153,11 @@ impl<F: Field, const C: usize, const R: usize> KMatrixConstants<F, C, R> {
                 .ln()
                 - utils::chi_plus(s, self.m1s[i], self.m2s[i]) / F::PI()
                     * ((self.m2s[i] - self.m1s[i]) / (self.m1s[i] + self.m2s[i]))
-                    * (self.m2s[i] / self.m1s[i]).fln()
+                    * F::ln(self.m2s[i] / self.m1s[i])
         }))
     }
     fn barrier_factor(s: F, m1: F, m2: F, mr: F, l: usize) -> F {
-        utils::blatt_weisskopf(s.fsqrt(), m1, m2, l) / utils::blatt_weisskopf(mr, m1, m2, l)
+        utils::blatt_weisskopf(F::sqrt(s), m1, m2, l) / utils::blatt_weisskopf(mr, m1, m2, l)
     }
     fn barrier_matrix(&self, s: F) -> SMatrix<F, C, R> {
         SMatrix::from_fn(|i, a| {
@@ -171,17 +170,17 @@ impl<F: Field, const C: usize, const R: usize> KMatrixConstants<F, C, R> {
         SMatrix::from_fn(|i, j| {
             (0..R)
                 .map(|a| {
-                    (bf[(i, a)]
-                        * bf[(j, a)]
-                        * (self.g[(i, a)] * self.g[(j, a)]
-                            + (self.c[(i, j)]) * (self.mrs[a].fpowi(2) - s)))
-                        .c()
-                        * self.pole_product_remainder(s, a)
+                    Complex::from(
+                        bf[(i, a)]
+                            * bf[(j, a)]
+                            * (self.g[(i, a)] * self.g[(j, a)]
+                                + (self.c[(i, j)]) * (self.mrs[a].powi(2) - s)),
+                    ) * self.pole_product_remainder(s, a)
                 })
                 .sum::<Complex<F>>()
                 * self
                     .adler_zero
-                    .map_or(F::ONE, |az| (s - az.s_0) / az.s_norm)
+                    .map_or(F::one(), |az| (s - az.s_0) / az.s_norm)
         })
     }
 
@@ -189,7 +188,7 @@ impl<F: Field, const C: usize, const R: usize> KMatrixConstants<F, C, R> {
         (0..R)
             .filter_map(|a| {
                 if a != a_i {
-                    Some(self.mrs[a].fpowi(2) - s)
+                    Some(self.mrs[a].powi(2) - s)
                 } else {
                     None
                 }
@@ -197,16 +196,7 @@ impl<F: Field, const C: usize, const R: usize> KMatrixConstants<F, C, R> {
             .product()
     }
     fn pole_product(&self, s: F) -> F {
-        (0..R).map(|a| (self.mrs[a].fpowi(2) - s)).product()
-    }
-
-    fn ikc_inv(&self, s: F, channel: usize) -> SVector<Complex<F>, C> {
-        let i_mat = SMatrix::<Complex<F>, C, C>::identity().scale(self.pole_product(s));
-        let k_mat = self.k_matrix(s);
-        let c_mat = self.c_matrix(s);
-        let ikc_mat = i_mat + k_mat * c_mat;
-        let ikc_inv_mat = ikc_mat.try_inverse().unwrap();
-        ikc_inv_mat.row(channel).transpose()
+        (0..R).map(|a| (self.mrs[a].powi(2) - s)).product()
     }
 
     fn p_vector(
@@ -226,6 +216,17 @@ impl<F: Field, const C: usize, const R: usize> KMatrixConstants<F, C, R> {
         ikc_inv_vec.dot(&Self::p_vector(betas, pvector_constants_mat))
     }
 }
+impl<F: Field + RealField + 'static, const C: usize, const R: usize> KMatrixConstants<F, C, R> {
+    fn ikc_inv(&self, s: F, channel: usize) -> SVector<Complex<F>, C> {
+        let i_mat = SMatrix::<Complex<F>, C, C>::identity().scale(self.pole_product(s));
+        let k_mat = self.k_matrix(s);
+        let c_mat = self.c_matrix(s);
+        let ikc_mat = i_mat + k_mat * c_mat;
+        let ikc_inv_mat = ikc_mat.try_inverse().unwrap();
+        ikc_inv_mat.row(channel).transpose()
+    }
+}
+
 #[derive(Clone)]
 #[allow(clippy::type_complexity)]
 pub struct KMatrixF0<F: Field> {
@@ -235,32 +236,32 @@ pub struct KMatrixF0<F: Field> {
     data: Vec<(SVector<Complex<F>, 5>, SMatrix<Complex<F>, 5, 5>)>,
 }
 #[rustfmt::skip]
-impl<F: Field> KMatrixF0<F> {
+impl<F: Field + 'static> KMatrixF0<F> {
     pub fn new(channel: usize, decay: Decay) -> Self {
         Self {
             channel,
             decay,
             constants: KMatrixConstants {
-                g: SMatrix::<F, 5, 5>::from_vec(F::fv(vec![
+                g: SMatrix::<F, 5, 5>::from_vec(convert_vec!(vec![
                      0.74987, -0.01257,  0.27536, -0.15102,  0.36103,
                      0.06401,  0.00204,  0.77413,  0.50999,  0.13112,
                     -0.23417, -0.01032,  0.72283,  0.11934,  0.36792, 
                      0.01270,  0.26700,  0.09214,  0.02742, -0.04025,
                     -0.14242,  0.22780,  0.15981,  0.16272, -0.17397,  
-                ])),
-                c: SMatrix::<F, 5, 5>::from_vec(F::fv(vec![
+                ], F)),
+                c: SMatrix::<F, 5, 5>::from_vec(convert_vec!(vec![
                      0.03728,  0.00000, -0.01398, -0.02203,  0.01397,
                      0.00000,  0.00000,  0.00000,  0.00000,  0.00000,
                     -0.01398,  0.00000,  0.02349,  0.03101, -0.04003,
                     -0.02203,  0.00000,  0.03101, -0.13769, -0.06722,
                      0.01397,  0.00000, -0.04003, -0.06722, -0.28401,
-                ])),
-                m1s: F::fa([0.1349768, 2.0 * 0.1349768, 0.493677, 0.547862, 0.547862]),
-                m2s: F::fa([0.1349768, 2.0 * 0.1349768, 0.497611, 0.547862, 0.95778]),
-                mrs: F::fa([0.51461, 0.90630, 1.23089, 1.46104, 1.69611]),
+                ], F)),
+                m1s: convert_array!([0.1349768, 2.0 * 0.1349768, 0.493677, 0.547862, 0.547862], F),
+                m2s: convert_array!([0.1349768, 2.0 * 0.1349768, 0.497611, 0.547862, 0.95778], F),
+                mrs: convert_array!([0.51461, 0.90630, 1.23089, 1.46104, 1.69611], F),
                 adler_zero: Some(AdlerZero {
-                    s_0: F::f(0.0091125),
-                    s_norm: F::ONE,
+                    s_0: convert!(0.0091125, F),
+                    s_norm: F::one(),
                 }),
                 l: 0,
             },
@@ -269,7 +270,7 @@ impl<F: Field> KMatrixF0<F> {
     }
 }
 
-impl<F: Field> Node<F> for KMatrixF0<F> {
+impl<F: Field + RealField> Node<F> for KMatrixF0<F> {
     fn precalculate(&mut self, dataset: &Dataset<F>) -> Result<(), RustitudeError> {
         self.data = dataset
             .events
@@ -278,7 +279,7 @@ impl<F: Field> Node<F> for KMatrixF0<F> {
                 let s = self.decay.resonance_p4(event).m2();
                 let barrier_mat = self.constants.barrier_matrix(s);
                 let pvector_constants = SMatrix::<Complex<F>, 5, 5>::from_fn(|i, a| {
-                    barrier_mat[(i, a)].c()
+                    Complex::from(barrier_mat[(i, a)])
                         * self.constants.g[(i, a)]
                         * self.constants.pole_product_remainder(s, a)
                 });
@@ -326,27 +327,27 @@ pub struct KMatrixF2<F: Field> {
     data: Vec<(SVector<Complex<F>, 4>, SMatrix<Complex<F>, 4, 4>)>,
 }
 #[rustfmt::skip]
-impl<F: Field> KMatrixF2<F> {
+impl<F: Field + 'static> KMatrixF2<F> {
     pub fn new(channel: usize, decay: Decay) -> Self {
         Self {
             channel,
             decay,
             constants: KMatrixConstants {
-                g: SMatrix::<F, 4, 4>::from_vec(F::fv(vec![
+                g: SMatrix::<F, 4, 4>::from_vec(convert_vec!(vec![
                      0.40033,  0.15479, -0.08900, -0.00113,
                      0.01820,  0.17300,  0.32393,  0.15256,
                     -0.06709,  0.22941, -0.43133,  0.23721,
                     -0.49924,  0.19295,  0.27975, -0.03987,
-                ])),
-                c: SMatrix::<F, 4, 4>::from_vec(F::fv(vec![
+                ], F)),
+                c: SMatrix::<F, 4, 4>::from_vec(convert_vec!(vec![
                     -0.04319,  0.00000,  0.00984,  0.01028,
                      0.00000,  0.00000,  0.00000,  0.00000,
                      0.00984,  0.00000, -0.07344,  0.05533,
                      0.01028,  0.00000,  0.05533, -0.05183,
-                ])),
-                m1s: F::fa([0.1349768, 2.0 * 0.1349768, 0.493677, 0.547862]),
-                m2s: F::fa([0.1349768, 2.0 * 0.1349768, 0.497611, 0.547862]),
-                mrs: F::fa([1.15299, 1.48359, 1.72923, 1.96700]),
+                ], F)),
+                m1s: convert_array!([0.1349768, 2.0 * 0.1349768, 0.493677, 0.547862], F),
+                m2s: convert_array!([0.1349768, 2.0 * 0.1349768, 0.497611, 0.547862], F),
+                mrs: convert_array!([1.15299, 1.48359, 1.72923, 1.96700], F),
                 adler_zero: None,
                 l: 2,
             },
@@ -355,7 +356,7 @@ impl<F: Field> KMatrixF2<F> {
     }
 }
 
-impl<F: Field> Node<F> for KMatrixF2<F> {
+impl<F: Field + RealField> Node<F> for KMatrixF2<F> {
     fn precalculate(&mut self, dataset: &Dataset<F>) -> Result<(), RustitudeError> {
         self.data = dataset
             .events
@@ -364,7 +365,7 @@ impl<F: Field> Node<F> for KMatrixF2<F> {
                 let s = self.decay.resonance_p4(event).m2();
                 let barrier_mat = self.constants.barrier_matrix(s);
                 let pvector_constants = SMatrix::<Complex<F>, 4, 4>::from_fn(|i, a| {
-                    barrier_mat[(i, a)].c()
+                    Complex::from(barrier_mat[(i, a)])
                         * self.constants.g[(i, a)]
                         * self.constants.pole_product_remainder(s, a)
                 });
@@ -410,23 +411,23 @@ pub struct KMatrixA0<F: Field> {
     data: Vec<(SVector<Complex<F>, 2>, SMatrix<Complex<F>, 2, 2>)>,
 }
 #[rustfmt::skip]
-impl<F: Field> KMatrixA0<F> {
+impl<F: Field + 'static> KMatrixA0<F> {
     pub fn new(channel: usize, decay: Decay) -> Self {
         Self {
             channel,
             decay,
             constants: KMatrixConstants {
-                g: SMatrix::<F, 2, 2>::from_vec(F::fv(vec![
+                g: SMatrix::<F, 2, 2>::from_vec(convert_vec!(vec![
                     0.43215, -0.28825, 
                     0.19000,  0.43372
-                ])),
-                c: SMatrix::<F, 2, 2>::from_vec(F::fv(vec![
+                ], F)),
+                c: SMatrix::<F, 2, 2>::from_vec(convert_vec!(vec![
                     0.00000,  0.00000,
                     0.00000,  0.00000
-                ])),
-                m1s: F::fa([0.1349768, 0.493677]),
-                m2s: F::fa([0.547862, 0.497611]),
-                mrs: F::fa([0.95395, 1.26767]),
+                ], F)),
+                m1s: convert_array!([0.1349768, 0.493677], F),
+                m2s: convert_array!([0.547862, 0.497611], F),
+                mrs: convert_array!([0.95395, 1.26767], F),
                 adler_zero: None,
                 l: 0,
             },
@@ -435,7 +436,7 @@ impl<F: Field> KMatrixA0<F> {
     }
 }
 
-impl<F: Field> Node<F> for KMatrixA0<F> {
+impl<F: Field + RealField> Node<F> for KMatrixA0<F> {
     fn precalculate(&mut self, dataset: &Dataset<F>) -> Result<(), RustitudeError> {
         self.data = dataset
             .events
@@ -444,7 +445,7 @@ impl<F: Field> Node<F> for KMatrixA0<F> {
                 let s = self.decay.resonance_p4(event).m2();
                 let barrier_mat = self.constants.barrier_matrix(s);
                 let pvector_constants = SMatrix::<Complex<F>, 2, 2>::from_fn(|i, a| {
-                    barrier_mat[(i, a)].c()
+                    Complex::from(barrier_mat[(i, a)])
                         * self.constants.g[(i, a)]
                         * self.constants.pole_product_remainder(s, a)
                 });
@@ -484,24 +485,24 @@ pub struct KMatrixA2<F: Field> {
     data: Vec<(SVector<Complex<F>, 3>, SMatrix<Complex<F>, 3, 2>)>,
 }
 #[rustfmt::skip]
-impl<F: Field> KMatrixA2<F> {
+impl<F: Field + 'static> KMatrixA2<F> {
     pub fn new(channel: usize, decay: Decay) -> Self {
         Self {
             channel,
             decay,
             constants: KMatrixConstants {
-                g: SMatrix::<F, 3, 2>::from_vec(F::fv(vec![
+                g: SMatrix::<F, 3, 2>::from_vec(convert_vec!(vec![
                      0.30073,  0.21426, -0.09162,
                      0.68567,  0.12543,  0.00184 
-                ])),
-                c: SMatrix::<F, 3, 3>::from_vec(F::fv(vec![
+                ], F)),
+                c: SMatrix::<F, 3, 3>::from_vec(convert_vec!(vec![
                     -0.40184,  0.00033, -0.08707,
                      0.00033, -0.21416, -0.06193,
                     -0.08707, -0.06193, -0.17435,
-                ])),
-                m1s: F::fa([0.1349768, 0.493677, 0.1349768]),
-                m2s: F::fa([0.547862, 0.497611, 0.95778]),
-                mrs: F::fa([1.30080, 1.75351]),
+                ], F)),
+                m1s: convert_array!([0.1349768, 0.493677, 0.1349768], F),
+                m2s: convert_array!([0.547862, 0.497611, 0.95778], F),
+                mrs: convert_array!([1.30080, 1.75351], F),
                 adler_zero: None,
                 l: 2,
             },
@@ -510,7 +511,7 @@ impl<F: Field> KMatrixA2<F> {
     }
 }
 
-impl<F: Field> Node<F> for KMatrixA2<F> {
+impl<F: Field + RealField> Node<F> for KMatrixA2<F> {
     fn precalculate(&mut self, dataset: &Dataset<F>) -> Result<(), RustitudeError> {
         self.data = dataset
             .events
@@ -519,7 +520,7 @@ impl<F: Field> Node<F> for KMatrixA2<F> {
                 let s = self.decay.resonance_p4(event).m2();
                 let barrier_mat = self.constants.barrier_matrix(s);
                 let pvector_constants = SMatrix::<Complex<F>, 3, 2>::from_fn(|i, a| {
-                    barrier_mat[(i, a)].c()
+                    Complex::from(barrier_mat[(i, a)])
                         * self.constants.g[(i, a)]
                         * self.constants.pole_product_remainder(s, a)
                 });
@@ -559,24 +560,24 @@ pub struct KMatrixRho<F: Field> {
     data: Vec<(SVector<Complex<F>, 3>, SMatrix<Complex<F>, 3, 2>)>,
 }
 #[rustfmt::skip]
-impl<F: Field> KMatrixRho<F> {
+impl<F: Field + 'static> KMatrixRho<F> {
     pub fn new(channel: usize, decay: Decay) -> Self {
         Self {
             channel,
             decay,
             constants: KMatrixConstants {
-                g: SMatrix::<F, 3, 2>::from_vec(F::fv(vec![
+                g: SMatrix::<F, 3, 2>::from_vec(convert_vec!(vec![
                      0.28023,  0.01806,  0.06501,
                      0.16318,  0.53879,  0.00495,
-                ])),
-                c: SMatrix::<F, 3, 3>::from_vec(F::fv(vec![
+                ], F)),
+                c: SMatrix::<F, 3, 3>::from_vec(convert_vec!(vec![
                     -0.06948,  0.00000,  0.07958,
                      0.00000,  0.00000,  0.00000,
                      0.07958,  0.00000, -0.60000,
-                ])),
-                m1s: F::fa([0.1349768, 2.0 * 0.1349768, 0.493677]),
-                m2s: F::fa([0.1349768, 2.0 * 0.1349768, 0.497611]),
-                mrs: F::fa([0.71093, 1.58660]),
+                ], F)),
+                m1s: convert_array!([0.1349768, 2.0 * 0.1349768, 0.493677], F),
+                m2s: convert_array!([0.1349768, 2.0 * 0.1349768, 0.497611], F),
+                mrs: convert_array!([0.71093, 1.58660], F),
                 adler_zero: None,
                 l: 1,
             },
@@ -585,7 +586,7 @@ impl<F: Field> KMatrixRho<F> {
     }
 }
 
-impl<F: Field> Node<F> for KMatrixRho<F> {
+impl<F: Field + RealField> Node<F> for KMatrixRho<F> {
     fn precalculate(&mut self, dataset: &Dataset<F>) -> Result<(), RustitudeError> {
         self.data = dataset
             .events
@@ -594,7 +595,7 @@ impl<F: Field> Node<F> for KMatrixRho<F> {
                 let s = self.decay.resonance_p4(event).m2();
                 let barrier_mat = self.constants.barrier_matrix(s);
                 let pvector_constants = SMatrix::<Complex<F>, 3, 2>::from_fn(|i, a| {
-                    barrier_mat[(i, a)].c()
+                    Complex::from(barrier_mat[(i, a)])
                         * self.constants.g[(i, a)]
                         * self.constants.pole_product_remainder(s, a)
                 });
@@ -634,22 +635,22 @@ pub struct KMatrixPi1<F: Field> {
     data: Vec<(SVector<Complex<F>, 2>, SMatrix<Complex<F>, 2, 1>)>,
 }
 #[rustfmt::skip]
-impl<F: Field> KMatrixPi1<F> {
+impl<F: Field + 'static> KMatrixPi1<F> {
     pub fn new(channel: usize, decay: Decay) -> Self {
         Self {
             channel,
             decay,
             constants: KMatrixConstants {
-                g: SMatrix::<F, 2, 1>::from_vec(F::fv(vec![
+                g: SMatrix::<F, 2, 1>::from_vec(convert_vec!(vec![
                     0.80564,  1.04595
-                ])),
-                c: SMatrix::<F, 2, 2>::from_vec(F::fv(vec![
+                ], F)),
+                c: SMatrix::<F, 2, 2>::from_vec(convert_vec!(vec![
                     1.05000,  0.15163,
                     0.15163, -0.24611,
-                ])),
-                m1s: F::fa([0.1349768, 0.1349768]),
-                m2s: F::fa([0.547862, 0.95778]),
-                mrs: F::fa([1.38552]),
+                ], F)),
+                m1s: convert_array!([0.1349768, 0.1349768], F),
+                m2s: convert_array!([0.547862, 0.95778], F),
+                mrs: convert_array!([1.38552], F),
                 adler_zero: None,
                 l: 1,
             },
@@ -658,7 +659,7 @@ impl<F: Field> KMatrixPi1<F> {
     }
 }
 
-impl<F: Field> Node<F> for KMatrixPi1<F> {
+impl<F: Field + RealField> Node<F> for KMatrixPi1<F> {
     fn precalculate(&mut self, dataset: &Dataset<F>) -> Result<(), RustitudeError> {
         self.data = dataset
             .events
@@ -667,7 +668,7 @@ impl<F: Field> Node<F> for KMatrixPi1<F> {
                 let s = self.decay.resonance_p4(event).m2();
                 let barrier_mat = self.constants.barrier_matrix(s);
                 let pvector_constants = SMatrix::<Complex<F>, 2, 1>::from_fn(|i, a| {
-                    barrier_mat[(i, a)].c()
+                    Complex::from(barrier_mat[(i, a)])
                         * self.constants.g[(i, a)]
                         * self.constants.pole_product_remainder(s, a)
                 });

--- a/crates/rustitude-gluex/src/sdmes.rs
+++ b/crates/rustitude-gluex/src/sdmes.rs
@@ -32,18 +32,15 @@ impl<F: Field> Node<F> for TwoPiSDME<F> {
             .par_iter()
             .map(|event| {
                 let (_, y, _, p) = self.decay.coordinates(self.frame, 0, event);
-                let big_phi = y.dot(&event.eps).fatan2(
-                    event
-                        .beam_p4
-                        .momentum()
-                        .normalize()
-                        .dot(&event.eps.cross(&y)),
+                let big_phi = F::atan2(
+                    y.dot(&event.eps),
+                    event.beam_p4.direction().dot(&event.eps.cross(&y)),
                 );
-                let pgamma = event.eps.norm();
+                let pgamma = event.eps_mag();
                 (
-                    p.theta_cos().fpowi(2),
-                    F::fsin(p.theta()).fpowi(2),
-                    F::fsin(F::TWO * p.theta()),
+                    p.theta_cos().powi(2),
+                    F::sin(p.theta()).powi(2),
+                    F::sin(convert!(2, F) * p.theta()),
                     p.phi(),
                     big_phi,
                     pgamma,
@@ -65,23 +62,22 @@ impl<F: Field> Node<F> for TwoPiSDME<F> {
         let rho_102 = parameters[7];
         let rho_1n12 = parameters[8];
 
-        Ok(F::fsqrt(F::fabs(
-            (F::THREE / (F::FOUR * F::PI()))
-                * (F::f(0.5) * (F::ONE - rho_000)
-                    + F::f(0.5) * (F::THREE * rho_000 - F::ONE) * cossqtheta
-                    - F::SQRT_2() * rho_100 * sin2theta * F::fcos(phi)
-                    - rho_1n10 * sinsqtheta * F::fcos(F::TWO * phi))
+        Ok(Complex::from(F::sqrt(F::abs(
+            (convert!(3, F) / (convert!(4, F) * F::PI()))
+                * (convert!(0.5, F) * (F::one() - rho_000)
+                    + convert!(0.5, F) * (convert!(3, F) * rho_000 - F::one()) * cossqtheta
+                    - F::SQRT_2() * rho_100 * sin2theta * F::cos(phi)
+                    - rho_1n10 * sinsqtheta * F::cos(convert!(2, F) * phi))
                 - pgamma
-                    * F::fcos(F::TWO * big_phi)
+                    * F::cos(convert!(2, F) * big_phi)
                     * (rho_111 * sinsqtheta + rho_001 * cossqtheta
-                        - F::SQRT_2() * rho_101 * sin2theta * F::fcos(phi)
-                        - rho_1n11 * sinsqtheta * F::fcos(F::TWO * phi))
+                        - F::SQRT_2() * rho_101 * sin2theta * F::cos(phi)
+                        - rho_1n11 * sinsqtheta * F::cos(convert!(2, F) * phi))
                 - pgamma
-                    * F::fsin(F::TWO * big_phi)
-                    * (F::SQRT_2() * rho_102 * sin2theta * F::fsin(phi)
-                        + rho_1n12 * sinsqtheta * F::fsin(F::TWO * phi)),
-        ))
-        .c())
+                    * F::sin(convert!(2, F) * big_phi)
+                    * (F::SQRT_2() * rho_102 * sin2theta * F::sin(phi)
+                        + rho_1n12 * sinsqtheta * F::sin(convert!(2, F) * phi)),
+        ))))
     }
 
     fn parameters(&self) -> Vec<String> {
@@ -129,26 +125,19 @@ impl<F: Field> Node<F> for ThreePiSDME<F> {
                 let res_p4 = self.decay.resonance_p4(event);
                 let p1_res_p4 = self.decay.primary_p4(event).boost_along(&res_p4);
                 let p2_res_p4 = self.decay.primary_p4(event).boost_along(&res_p4);
-                let norm = p1_res_p4
-                    .momentum()
-                    .cross(&p2_res_p4.momentum())
-                    .normalize();
+                let norm = p1_res_p4.momentum().cross(&p2_res_p4.momentum()).unit();
                 let (_, y, _, p) = self
                     .frame
                     .coordinates_from_boosted_vec(self.decay, &norm, event);
-                let big_phi = F::fatan2(
+                let big_phi = F::atan2(
                     y.dot(&event.eps),
-                    event
-                        .beam_p4
-                        .momentum()
-                        .normalize()
-                        .dot(&event.eps.cross(&y)),
+                    event.beam_p4.direction().dot(&event.eps.cross(&y)),
                 );
-                let pgamma = event.eps.norm();
+                let pgamma = event.eps_mag();
                 (
-                    p.theta_cos().fpowi(2),
-                    F::fsin(p.theta()).fpowi(2),
-                    F::fsin(F::TWO * p.theta()),
+                    p.theta_cos().powi(2),
+                    F::sin(p.theta()).powi(2),
+                    F::sin(convert!(2, F) * p.theta()),
                     p.phi(),
                     big_phi,
                     pgamma,
@@ -170,23 +159,22 @@ impl<F: Field> Node<F> for ThreePiSDME<F> {
         let rho_102 = parameters[7];
         let rho_1n12 = parameters[8];
 
-        Ok(F::fsqrt(F::fabs(
-            (F::THREE / (F::FOUR * F::PI()))
-                * (F::f(0.5) * (F::ONE - rho_000)
-                    + F::f(0.5) * (F::THREE * rho_000 - F::ONE) * cossqtheta
-                    - F::SQRT_2() * rho_100 * sin2theta * F::fcos(phi)
-                    - rho_1n10 * sinsqtheta * F::fcos(F::TWO * phi))
+        Ok(Complex::from(F::sqrt(F::abs(
+            (convert!(3, F) / (convert!(4, F) * F::PI()))
+                * (convert!(0.5, F) * (F::one() - rho_000)
+                    + convert!(0.5, F) * (convert!(3, F) * rho_000 - F::one()) * cossqtheta
+                    - F::SQRT_2() * rho_100 * sin2theta * F::cos(phi)
+                    - rho_1n10 * sinsqtheta * F::cos(convert!(2, F) * phi))
                 - pgamma
-                    * F::fcos(F::TWO * big_phi)
+                    * F::cos(convert!(2, F) * big_phi)
                     * (rho_111 * sinsqtheta + rho_001 * cossqtheta
-                        - F::SQRT_2() * rho_101 * sin2theta * F::fcos(phi)
-                        - rho_1n11 * sinsqtheta * F::fcos(F::TWO * phi))
+                        - F::SQRT_2() * rho_101 * sin2theta * F::cos(phi)
+                        - rho_1n11 * sinsqtheta * F::cos(convert!(2, F) * phi))
                 - pgamma
-                    * F::fsin(F::TWO * big_phi)
-                    * (F::SQRT_2() * rho_102 * sin2theta * F::fsin(phi)
-                        + rho_1n12 * sinsqtheta * F::fsin(F::TWO * phi)),
-        ))
-        .c())
+                    * F::sin(convert!(2, F) * big_phi)
+                    * (F::SQRT_2() * rho_102 * sin2theta * F::sin(phi)
+                        + rho_1n12 * sinsqtheta * F::sin(convert!(2, F) * phi)),
+        ))))
     }
 
     fn parameters(&self) -> Vec<String> {
@@ -232,18 +220,15 @@ impl<F: Field> Node<F> for VecRadiativeSDME<F> {
             .par_iter()
             .map(|event| {
                 let (_, y, _, p) = self.decay.coordinates(self.frame, 0, event);
-                let big_phi = y.dot(&event.eps).fatan2(
-                    event
-                        .beam_p4
-                        .momentum()
-                        .normalize()
-                        .dot(&event.eps.cross(&y)),
+                let big_phi = F::atan2(
+                    y.dot(&event.eps),
+                    event.beam_p4.direction().dot(&event.eps.cross(&y)),
                 );
-                let pgamma = event.eps.norm();
+                let pgamma = event.eps_mag();
                 (
-                    p.theta_cos().fpowi(2),
-                    F::fsin(p.theta()).fpowi(2),
-                    F::fsin(F::TWO * p.theta()),
+                    p.theta_cos().powi(2),
+                    F::sin(p.theta()).powi(2),
+                    F::sin(convert!(2, F) * p.theta()),
                     p.phi(),
                     big_phi,
                     pgamma,
@@ -265,23 +250,24 @@ impl<F: Field> Node<F> for VecRadiativeSDME<F> {
         let rho_102 = parameters[7];
         let rho_1n12 = parameters[8];
 
-        Ok(F::fsqrt(F::fabs(
-            (F::THREE / (F::EIGHT * F::PI()))
-                * (F::ONE - sinsqtheta * F::f(0.5) * (F::ONE - rho_000) - rho_000 * cossqtheta
-                    + rho_1n10 * sinsqtheta * F::fcos(F::TWO * phi)
-                    + F::SQRT_2() * rho_100 * sin2theta * F::fcos(phi)
+        Ok(Complex::from(F::sqrt(F::abs(
+            (convert!(3, F) / (convert!(8, F) * F::PI()))
+                * (F::one()
+                    - sinsqtheta * convert!(0.5, F) * (F::one() - rho_000)
+                    - rho_000 * cossqtheta
+                    + rho_1n10 * sinsqtheta * F::cos(convert!(2, F) * phi)
+                    + F::SQRT_2() * rho_100 * sin2theta * F::cos(phi)
                     - pgamma
-                        * F::fcos(F::TWO * big_phi)
-                        * (F::TWO * rho_111
+                        * F::cos(convert!(2, F) * big_phi)
+                        * (convert!(2, F) * rho_111
                             + (rho_001 - rho_111) * sinsqtheta
-                            + rho_1n11 * sinsqtheta * F::fcos(F::TWO * phi)
-                            + F::SQRT_2() * rho_101 * sin2theta * F::fcos(phi))
+                            + rho_1n11 * sinsqtheta * F::cos(convert!(2, F) * phi)
+                            + F::SQRT_2() * rho_101 * sin2theta * F::cos(phi))
                     + pgamma
-                        * F::fsin(F::TWO * big_phi)
-                        * (rho_1n12 * sinsqtheta * F::fsin(F::TWO * phi)
-                            + F::SQRT_2() * rho_102 * sin2theta * F::fsin(phi))),
-        ))
-        .c())
+                        * F::sin(convert!(2, F) * big_phi)
+                        * (rho_1n12 * sinsqtheta * F::sin(convert!(2, F) * phi)
+                            + F::SQRT_2() * rho_102 * sin2theta * F::sin(phi))),
+        ))))
     }
 
     fn parameters(&self) -> Vec<String> {

--- a/crates/rustitude-gluex/src/utils.rs
+++ b/crates/rustitude-gluex/src/utils.rs
@@ -1,32 +1,30 @@
 use std::{fmt::Display, num::ParseIntError, str::FromStr};
 
 use factorial::Factorial;
-use rustitude_core::prelude::*;
+use rustitude_core::{convert, prelude::*};
 use sphrs::Coordinates;
 use thiserror::Error;
 
 pub fn breakup_momentum<F: Field>(m0: F, m1: F, m2: F) -> F {
-    F::fsqrt(F::fabs(
-        m0.fpowi(4) + m1.fpowi(4) + m2.fpowi(4)
-            - F::TWO
-                * (m0.fpowi(2) * m1.fpowi(2)
-                    + m0.fpowi(2) * m2.fpowi(2)
-                    + m1.fpowi(2) * m2.fpowi(2)),
-    )) / (F::TWO * m0)
+    F::sqrt(F::abs(
+        m0.powi(4) + m1.powi(4) + m2.powi(4)
+            - convert!(2, F)
+                * (m0.powi(2) * m1.powi(2) + m0.powi(2) * m2.powi(2) + m1.powi(2) * m2.powi(2)),
+    )) / (convert!(2, F) * m0)
 }
 
 /// Computes the ([`Complex<F>`]) breakup momentum of a particle with mass `m0` decaying into two particles
 /// with masses `m1` and `m2`.
 pub fn breakup_momentum_c<F: Field>(m0: F, m1: F, m2: F) -> Complex<F> {
-    rho(m0.fpowi(2), m1, m2) * m0 / F::TWO
+    rho(m0.powi(2), m1, m2) * m0 / convert!(2, F)
 }
 
 pub fn chi_plus<F: Field>(s: F, m1: F, m2: F) -> Complex<F> {
-    (F::ONE - ((m1 + m2) * (m1 + m2)) / s).c()
+    Complex::from(F::one() - ((m1 + m2) * (m1 + m2)) / s)
 }
 
 pub fn chi_minus<F: Field>(s: F, m1: F, m2: F) -> Complex<F> {
-    (F::ONE - ((m1 - m2) * (m1 - m2)) / s).c()
+    Complex::from(F::one() - ((m1 - m2) * (m1 - m2)) / s)
 }
 
 pub fn rho<F: Field>(s: F, m1: F, m2: F) -> Complex<F> {
@@ -35,18 +33,22 @@ pub fn rho<F: Field>(s: F, m1: F, m2: F) -> Complex<F> {
 
 pub fn blatt_weisskopf<F: Field>(m0: F, m1: F, m2: F, l: usize) -> F {
     let q = breakup_momentum(m0, m1, m2);
-    let z = q.fpowi(2) / F::f(0.1973).fpowi(2);
+    let z = q.powi(2) / convert!(0.1973, F).powi(2);
     match l {
-        0 => F::ONE,
-        1 => F::fsqrt((F::TWO * z) / (z + F::ONE)),
-        2 => F::fsqrt((F::f(13.0) * z.fpowi(2)) / ((z - F::THREE).fpowi(2) + F::NINE * z)),
-        3 => F::fsqrt(
-            (F::f(277.0) * z.fpowi(3))
-                / (z * (z - F::f(15.0)).fpowi(2) + F::NINE * (F::TWO * z - F::FIVE).fpowi(2)),
+        0 => F::one(),
+        1 => F::sqrt((convert!(2, F) * z) / (z + F::one())),
+        2 => F::sqrt(
+            (convert!(13.0, F) * z.powi(2)) / ((z - convert!(3, F)).powi(2) + convert!(9, F) * z),
         ),
-        4 => F::fsqrt(
-            (F::f(12746.0) * z.fpowi(4)) / (z.fpowi(2) - F::f(45.0) * z + F::f(105.0)).fpowi(2)
-                + F::f(25.0) * z * (F::TWO * z - F::f(21.0)).fpowi(2),
+        3 => F::sqrt(
+            (convert!(277.0, F) * z.powi(3))
+                / (z * (z - convert!(15.0, F)).powi(2)
+                    + convert!(9, F) * (convert!(2, F) * z - convert!(5, F)).powi(2)),
+        ),
+        4 => F::sqrt(
+            (convert!(12746.0, F) * z.powi(4))
+                / (z.powi(2) - convert!(45.0, F) * z + convert!(105.0, F)).powi(2)
+                + convert!(25.0, F) * z * (convert!(2, F) * z - convert!(21.0, F)).powi(2),
         ),
         l => panic!("L = {l} is not yet implemented"),
     }
@@ -59,19 +61,23 @@ pub fn blatt_weisskopf<F: Field>(m0: F, m1: F, m2: F, l: usize) -> F {
 /// `m2`, the absolute value of this function can be safely assumed to be equal to its value.
 pub fn blatt_weisskopf_c<F: Field>(m0: F, m1: F, m2: F, l: usize) -> Complex<F> {
     let q = breakup_momentum_c(m0, m1, m2);
-    let z = q.powi(2) / F::f(0.1973).fpowi(2);
+    let z = q.powi(2) / convert!(0.1973, F).powi(2);
     match l {
-        0 => F::ONE.c(),
-        1 => Complex::sqrt((F::TWO.c() * z) / (z + F::ONE)),
-        2 => Complex::sqrt((z.powi(2) * F::f(13.0)) / ((z - F::THREE).powi(2) + z * F::NINE)),
+        0 => Complex::from(F::one()),
+        1 => Complex::sqrt((Complex::from(convert!(2, F)) * z) / (z + F::one())),
+        2 => Complex::sqrt(
+            (z.powi(2) * convert!(13.0, F)) / ((z - convert!(3, F)).powi(2) + z * convert!(9, F)),
+        ),
         3 => Complex::sqrt(
-            (z.powi(3) * F::f(277.0))
-                / (z * (z - F::f(15.0)).powi(2) + (z * F::TWO - F::FIVE).powi(2))
-                * F::NINE,
+            (z.powi(3) * convert!(277.0, F))
+                / (z * (z - convert!(15.0, F)).powi(2)
+                    + (z * convert!(2, F) - convert!(5, F)).powi(2))
+                * convert!(9, F),
         ),
         4 => Complex::sqrt(
-            (z.powi(4) * F::f(12746.0)) / (z.powi(2) - z * F::f(45.0) + F::f(105.0)).powi(2)
-                + z * F::f(25.0) * (z * F::TWO - F::f(21.0)).powi(2),
+            (z.powi(4) * convert!(12746.0, F))
+                / (z.powi(2) - z * convert!(45.0, F) + convert!(105.0, F)).powi(2)
+                + z * convert!(25.0, F) * (z * convert!(2, F) - convert!(21.0, F)).powi(2),
         ),
         l => panic!("L = {l} is not yet implemented"),
     }
@@ -82,22 +88,24 @@ pub fn small_wigner_d_matrix<F: Field>(beta: F, j: usize, m: isize, n: isize) ->
     let jmm = (j as i32 - m as i32) as u32;
     let jpn = (j as i32 + n as i32) as u32;
     let jmn = (j as i32 - n as i32) as u32;
-    let prefactor = F::fsqrt(F::convert_u32(
+    let prefactor = F::sqrt(convert!(
         jpm.factorial() * jmm.factorial() * jpn.factorial() * jmn.factorial(),
+        F
     ));
     let s_min = isize::max(0, n - m) as usize;
     let s_max = isize::min(jpn as isize, jmm as isize) as usize;
     let sum: F = (s_min..=s_max)
         .map(|s| {
-            (F::fpowi(-F::ONE, m as i32 - n as i32 + s as i32)
-                * (F::fcos(beta / F::TWO)
-                    .fpowi(2 * (j as i32) + n as i32 - m as i32 - 2 * (s as i32)))
-                * (F::fsin(beta / F::TWO).fpowi(m as i32 - n as i32 + 2 * s as i32)))
-                / F::convert_u32(
+            (F::powi(-F::one(), m as i32 - n as i32 + s as i32)
+                * (F::cos(beta / convert!(2, F))
+                    .powi(2 * (j as i32) + n as i32 - m as i32 - 2 * (s as i32)))
+                * (F::sin(beta / convert!(2, F)).powi(m as i32 - n as i32 + 2 * s as i32)))
+                / convert!(
                     (jpm - s as u32).factorial()
                         * (s as u32).factorial()
                         * ((m - n + s as isize) as u32).factorial()
                         * (jmm - s as u32).factorial(),
+                    F
                 )
         })
         .sum();
@@ -112,9 +120,9 @@ pub fn wigner_d_matrix<F: Field>(
     m: isize,
     n: isize,
 ) -> Complex<F> {
-    Complex::cis(-(F::convert_isize(m)) * alpha)
+    Complex::cis(convert!(-m, F) * alpha)
         * small_wigner_d_matrix(beta, j, m, n)
-        * Complex::cis(-(F::convert_isize(n)) * gamma)
+        * Complex::cis(convert!(-n, F) * gamma)
 }
 
 #[derive(Clone, Copy, Default, PartialEq)]
@@ -223,7 +231,7 @@ impl FromStr for Frame {
     }
 }
 
-pub fn coordinates<F: Field>(
+pub fn coordinates<F: Field + 'static>(
     x: &Vector3<F>,
     y: &Vector3<F>,
     z: &Vector3<F>,
@@ -245,18 +253,14 @@ impl Frame {
         let other_res_vec = other_p4.boost_along(&resonance_p4).momentum();
         let (x, y, z) = match self {
             Frame::Helicity => {
-                let z = -recoil_res_vec.normalize();
-                let y = beam_res_vec.cross(&z).normalize();
+                let z = -recoil_res_vec.unit();
+                let y = beam_res_vec.cross(&z).unit();
                 let x = y.cross(&z);
                 (x, y, z)
             }
             Frame::GottfriedJackson => {
-                let z = beam_res_vec.normalize();
-                let y = event
-                    .beam_p4
-                    .momentum()
-                    .cross(&(-recoil_res_vec))
-                    .normalize();
+                let z = beam_res_vec.unit();
+                let y = event.beam_p4.momentum().cross(&(-recoil_res_vec)).unit();
                 let x = y.cross(&z);
                 (x, y, z)
             }
@@ -274,18 +278,14 @@ impl Frame {
         let recoil_res_vec = event.recoil_p4.boost_along(&resonance_p4).momentum();
         let (x, y, z) = match self {
             Frame::Helicity => {
-                let z = -recoil_res_vec.normalize();
-                let y = beam_res_vec.cross(&z).normalize();
+                let z = -recoil_res_vec.unit();
+                let y = beam_res_vec.cross(&z).unit();
                 let x = y.cross(&z);
                 (x, y, z)
             }
             Frame::GottfriedJackson => {
-                let z = beam_res_vec.normalize();
-                let y = event
-                    .beam_p4
-                    .momentum()
-                    .cross(&(-recoil_res_vec))
-                    .normalize();
+                let z = beam_res_vec.unit();
+                let y = event.beam_p4.momentum().cross(&(-recoil_res_vec)).unit();
                 let x = y.cross(&z);
                 (x, y, z)
             }

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -9,7 +9,6 @@
 project = "rustitude"
 copyright = "2024, Nathaniel Dene Hoffman"
 author = "Nathaniel Dene Hoffman"
-release = "0.7.4"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/py-rustitude/README.md
+++ b/py-rustitude/README.md
@@ -79,8 +79,8 @@ f2 = gluex.resonances.KMatrixF2('f2', channel=2)
 a0p = gluex.resonances.KMatrixA0('a0+', channel=1)
 a0n = gluex.resonances.KMatrixA0('a0-', channel=1)
 a2 = gluex.resonances.KMatrixA2('a2', channel=1)
-s0p = gluex.harmonics.Zlm('Z00+', 0, 0, reflectivity=gluex.Reflectivity.Positive)
-s0n = gluex.harmonics.Zlm('Z00-', 0, 0, reflectivity=gluex.Reflectivity.Negative)
+s0p = gluex.harmonics.Zlm('Z00+', l=0, m=0, reflectivity='+')
+s0n = gluex.harmonics.Zlm('Z00-', 0, 0, '-')
 d2p = gluex.harmonics.Zlm('Z22+', 2, 2) # positive reflectivity is the default
 
 # Next, let's put them together into a model
@@ -122,6 +122,10 @@ nll = rt.ExtendedLogLikelihood(m_data, m_mc)
 
 res = nll([10.0] * mod.n_free) # automatic CPU parallelism without GIL
 print(res) # prints some value for the NLL
+
+mi = rt.minimizer(nll, method='Minuit') # use iminuit to create a Minuit minimizer
+mi.migrad() # run the Migrad algorithm
+print(mi) # print the fit result
 ```
 
 Automatic parallelism over the CPU can be disabled via function calls which support it (for example, `nll([10.0] * mod.n_free, parallel=False)` would run without parallel processing), and the number of CPUs used can be controlled via the `RAYON_NUM_THREADS` environment variable, which can be set before the code is run or modified inside the code (for example, `os.environ['RAYON_NUM_THREADS] = '5'` would ensure only five threads are used past that point in the code). By default, an unset value or the value of `'0'` will use all available cores.

--- a/py-rustitude/rustitude/__init__.pyi
+++ b/py-rustitude/rustitude/__init__.pyi
@@ -664,7 +664,6 @@ def minimizer(
     *args: Any,
     indices_data: list[int] | None = None,
     indices_mc: list[int] | None = None,
-    num_threads: int = 1,
     minimizer_kwargs: dict[str, Any] | None = None,
 ) -> Minuit: ...
 @overload
@@ -674,7 +673,6 @@ def minimizer(
     *args: Any,
     indices_data: list[int] | None = None,
     indices_mc: list[int] | None = None,
-    num_threads: int = 1,
     minimizer_kwargs: dict[str, Any] | None = None,
 ) -> Callable[[], OptimizeResult]: ...
 @overload
@@ -684,7 +682,6 @@ def minimizer(
     *args: Any,
     indices_data: list[int] | None = None,
     indices_mc: list[int] | None = None,
-    num_threads: int = 1,
     minimizer_kwargs: dict[str, Any] | None = None,
 ) -> RustMinimizer: ...
 def minimizer(
@@ -693,6 +690,5 @@ def minimizer(
     *args: Any,
     indices_data: list[int] | None = None,
     indices_mc: list[int] | None = None,
-    num_threads: int = 1,
     minimizer_kwargs: dict[str, Any] | None = None,
 ) -> Minuit | Callable[[], OptimizeResult] | RustMinimizer: ...

--- a/py-rustitude/src/manager.rs
+++ b/py-rustitude/src/manager.rs
@@ -1011,7 +1011,7 @@ impl NelderMead_64 {
     }
     fn best(&self) -> (Vec<f64>, f64) {
         let (x_best, fx_best) = self.0.best();
-        (x_best.clone(), *fx_best)
+        (x_best.data.as_vec().to_vec(), *fx_best)
     }
 }
 
@@ -1088,7 +1088,7 @@ impl NelderMead_32 {
     }
     fn best(&self) -> (Vec<f32>, f32) {
         let (x_best, fx_best) = self.0.best();
-        (x_best.clone(), *fx_best)
+        (x_best.data.as_vec().to_vec(), *fx_best)
     }
 }
 


### PR DESCRIPTION
This update update the `Field` trait by removing the `nalgebra::RealField` subtrait. This also allows for the removal of f-prefixed math methods. Rather than deprecate a ton of methods, I've chosen to just remove them, making this a rather breaking update (although I doubt anyone is using this crate so this is mostly just documentation for my own sake). A similar process was carried out in `ganesh`, so that has also been updated.

# Other changes
- Adds some macros (`convert!`, `convert_vec!`, and `convert_array!`) to make it easier to convert raw values to generics.
- Adds `Event::eps_mag()` for getting the magnitude of the EPS vector and a new trait `UnitVector` which provides a method `unit()` that is implemented for `nalgebra::Vector3` to quickly get a unit vector without needing `RealField`'s `normalize()` method.